### PR TITLE
Add validation against a list of emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+traefik-forward-auth

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following configuration is supported:
 |-csrf-cookie-name|string|CSRF Cookie Name (default "_forward_auth_csrf")|
 |-direct|bool|Run in direct mode (use own hostname as oppose to <br>X-Forwarded-Host, used for testing/development)
 |-domain|string|Comma separated list of email domains to allow|
+|-email|string|Comma separated list of emails to allow|
 |-lifetime|int|Session length in seconds (default 43200)|
 |-url-path|string|Callback URL (default "_oauth")|
 

--- a/forwardauth.go
+++ b/forwardauth.go
@@ -82,7 +82,7 @@ func (f *ForwardAuth) ValidateCookie(r *http.Request, c *http.Cookie) (bool, str
 }
 
 // Validate email against domain
-func (f *ForwardAuth) ValidateEmailDomain(email string) bool {
+func (f *ForwardAuth) validEmailDomain(email string) bool {
   parts := strings.Split(email, "@")
   if len(parts) < 2 {
     return false
@@ -98,7 +98,7 @@ func (f *ForwardAuth) ValidateEmailDomain(email string) bool {
 }
 
 // Validate email
-func (f *ForwardAuth) ValidateEmail(email string) bool {
+func (f *ForwardAuth) validEmail(email string) bool {
   for _, allowed := range f.Email {
     if email == allowed {
       return true
@@ -106,6 +106,15 @@ func (f *ForwardAuth) ValidateEmail(email string) bool {
   }
 
   return false
+}
+
+func (f *ForwardAuth) ValidateEmail(email string) bool {
+  // valid if not configured
+  if len(fw.Email) == 0 && len(fw.Domain) == 0 {
+    return true
+  }
+
+  return fw.validEmailDomain(email) || fw.validEmail(email)
 }
 
 

--- a/forwardauth.go
+++ b/forwardauth.go
@@ -36,6 +36,7 @@ type ForwardAuth struct {
   CookieSecure bool
 
   Domain []string
+  Email []string
 
   Direct bool
 }
@@ -80,25 +81,31 @@ func (f *ForwardAuth) ValidateCookie(r *http.Request, c *http.Cookie) (bool, str
   return true, parts[2], nil
 }
 
-// Validate email
-func (f *ForwardAuth) ValidateEmail(email string) bool {
-  if len(f.Domain) > 0 {
-    parts := strings.Split(email, "@")
-    if len(parts) < 2 {
-      return false
-    }
-    found := false
-    for _, domain := range f.Domain {
-      if domain == parts[1] {
-        found = true
-      }
-    }
-    if !found {
-      return false
+// Validate email against domain
+func (f *ForwardAuth) ValidateEmailDomain(email string) bool {
+  parts := strings.Split(email, "@")
+  if len(parts) < 2 {
+    return false
+  }
+
+  for _, domain := range f.Domain {
+    if domain == parts[1] {
+      return true
     }
   }
 
-  return true
+  return false
+}
+
+// Validate email
+func (f *ForwardAuth) ValidateEmail(email string) bool {
+  for _, allowed := range f.Email {
+    if email == allowed {
+      return true
+    }
+  }
+
+  return false
 }
 
 

--- a/forwardauth_test.go
+++ b/forwardauth_test.go
@@ -62,24 +62,54 @@ func TestValidateCookie(t *testing.T) {
   }
 }
 
-func TestValidateEmail(t *testing.T) {
+func TestValidateEmailDomain(t *testing.T) {
   fw = &ForwardAuth{}
 
   // Should allow any
-  if !fw.ValidateEmail("test@test.com") || !fw.ValidateEmail("one@two.com") {
-    t.Error("Should allow any domain if email domain is not defined")
+  if fw.ValidateEmailDomain("test@test.com") || fw.ValidateEmailDomain("one@two.com") {
+    t.Error("Should not allow any domain if email domain is not defined")
   }
 
   // Should block non matching domain
   fw.Domain = []string{"test.com"}
-  if fw.ValidateEmail("one@two.com") {
+  if fw.ValidateEmailDomain("one@two.com") {
     t.Error("Should not allow user from another domain")
   }
 
   // Should allow matching domain
   fw.Domain = []string{"test.com"}
-  if !fw.ValidateEmail("test@test.com") {
+  if !fw.ValidateEmailDomain("test@test.com") {
     t.Error("Should allow user from allowed domain")
+  }
+}
+
+func TestValidateEmail(t *testing.T) {
+  fw = &ForwardAuth{}
+
+  // Should allow any
+  if fw.ValidateEmail("test@test.com") || fw.ValidateEmail("one@two.com") {
+    t.Error("Should not allow any email if email is not defined")
+  }
+
+  // Should block non matching email
+  fw.Email = []string{"test@test.com"}
+  if fw.ValidateEmail("one@two.com") {
+    t.Error("Should not allow non matching emails")
+  }
+
+  // Should allow matching domain
+  fw.Email = []string{"test@test.com"}
+  if !fw.ValidateEmail("test@test.com") {
+    t.Error("Should allow matching email")
+  }
+
+  fw.Email = []string{"test@test.com","test@example.com"}
+  if !fw.ValidateEmail("test@test.com") {
+    t.Error("Should first email in list")
+  }
+
+  if !fw.ValidateEmail("test@example.com") {
+    t.Error("Should any email in list")
   }
 }
 

--- a/forwardauth_test.go
+++ b/forwardauth_test.go
@@ -66,19 +66,19 @@ func TestValidateEmailDomain(t *testing.T) {
   fw = &ForwardAuth{}
 
   // Should allow any
-  if fw.ValidateEmailDomain("test@test.com") || fw.ValidateEmailDomain("one@two.com") {
-    t.Error("Should not allow any domain if email domain is not defined")
+  if !fw.ValidateEmail("test@test.com") || !fw.ValidateEmail("one@two.com") {
+    t.Error("Should allow any domain if email domain is not defined")
   }
 
   // Should block non matching domain
   fw.Domain = []string{"test.com"}
-  if fw.ValidateEmailDomain("one@two.com") {
+  if fw.ValidateEmail("one@two.com") {
     t.Error("Should not allow user from another domain")
   }
 
   // Should allow matching domain
   fw.Domain = []string{"test.com"}
-  if !fw.ValidateEmailDomain("test@test.com") {
+  if !fw.ValidateEmail("test@test.com") {
     t.Error("Should allow user from allowed domain")
   }
 }
@@ -87,8 +87,8 @@ func TestValidateEmail(t *testing.T) {
   fw = &ForwardAuth{}
 
   // Should allow any
-  if fw.ValidateEmail("test@test.com") || fw.ValidateEmail("one@two.com") {
-    t.Error("Should not allow any email if email is not defined")
+  if !fw.ValidateEmail("test@test.com") || !fw.ValidateEmail("one@two.com") {
+    t.Error("Should allow any email if email is not defined")
   }
 
   // Should block non matching email

--- a/main.go
+++ b/main.go
@@ -65,8 +65,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
     return
   }
 
-  // Validate user
-  valid = fw.ValidateEmail(email)
+  // Validate email
+  valid = ( len(fw.Email) == 0 && len(fw.Domain) == 0 ) || fw.ValidateEmailDomain(email) || fw.ValidateEmail(email)
   if !valid {
     log.Debugf("Invalid email: %s", email)
     http.Error(w, "Not authorized", 401)
@@ -138,6 +138,7 @@ func main() {
   cookieSecret := flag.String("cookie-secret", "", "*Cookie secret (required)")
   cookieSecure := flag.Bool("cookie-secure", true, "Use secure cookies")
   domainList := flag.String("domain", "", "Comma separated list of email domains to allow")
+  emailList := flag.String("email", "", "Comma separated list of emails to allow")
   direct := flag.Bool("direct", false, "Run in direct mode (use own hostname as oppose to X-Forwarded-Host, used for testing/development)")
 
   flag.Parse()
@@ -174,6 +175,11 @@ func main() {
     domain = strings.Split(*domainList, ",")
   }
 
+  var email []string
+  if *emailList != "" {
+    email = strings.Split(*emailList, ",")
+  }
+
   // Setup
   fw = &ForwardAuth{
     Path: fmt.Sprintf("/%s", *path),
@@ -205,6 +211,7 @@ func main() {
     CookieSecure: *cookieSecure,
 
     Domain: domain,
+    Email: email,
 
     Direct: *direct,
   }

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
   }
 
   // Validate email
-  valid = ( len(fw.Email) == 0 && len(fw.Domain) == 0 ) || fw.ValidateEmailDomain(email) || fw.ValidateEmail(email)
+  valid = fw.ValidateEmail(email)
   if !valid {
     log.Debugf("Invalid email: %s", email)
     http.Error(w, "Not authorized", 401)

--- a/main_test.go
+++ b/main_test.go
@@ -101,7 +101,7 @@ func TestHandler(t *testing.T) {
     t.Error("Request with invalid cookie shound't be authorised", res.StatusCode)
   }
 
-  // Should validate email
+  // Should validate email against domain
   req = newHttpRequest("foo")
 
   c = fw.MakeCookie(req, "test@example.com")
@@ -109,7 +109,42 @@ func TestHandler(t *testing.T) {
 
   res, _ = httpRequest(req, c)
   if res.StatusCode != 401 {
-    t.Error("Request with invalid cookie shound't be authorised", res.StatusCode)
+    t.Error("Request with invalid domain shound't be authorised", res.StatusCode)
+  }
+
+  // Should validate email
+  req = newHttpRequest("foo")
+
+  c = fw.MakeCookie(req, "fail@example.com")
+  fw.Email = []string{"test@example.com"}
+
+  res, _ = httpRequest(req, c)
+  if res.StatusCode != 401 {
+    t.Error("Request with invalid email shound't be authorised", res.StatusCode)
+  }
+
+  // Should validate email domain even with email also set
+  req = newHttpRequest("foo")
+
+  c = fw.MakeCookie(req, "pass@example.com")
+  fw.Domain = []string{"example.com"}
+  fw.Email = []string{"ignored@ignored.com"}
+
+  res, _ = httpRequest(req, c)
+  if res.StatusCode != 200 {
+    t.Error("Request with valid email domain shound be authorised", res.StatusCode)
+  }
+
+  // Should validate email and even if it doesnt match domain also set
+  req = newHttpRequest("foo")
+
+  c = fw.MakeCookie(req, "bypass@bypass.com")
+  fw.Domain = []string{"example.com"}
+  fw.Email = []string{"bypass@bypass.com"}
+
+  res, _ = httpRequest(req, c)
+  if res.StatusCode != 200 {
+    t.Error("Request with valid email shound be authorised", res.StatusCode)
   }
 
   // Should allow valid request email
@@ -117,6 +152,7 @@ func TestHandler(t *testing.T) {
 
   c = fw.MakeCookie(req, "test@example.com")
   fw.Domain = []string{}
+  fw.Email = []string{}
 
   res, _ = httpRequest(req, c)
   if res.StatusCode != 200 {


### PR DESCRIPTION
Allows an email or list of emails to be used for restricting access

**Use cases:**
- Smaller setups where you just need to overlay oauth for a
  handful of random gmails.
- Situations where you need to enable singular email addresses outside
  your domain in addition

**Whats changed:**
Adds new `email` flag similar to the existing `domain` flag. csv enabled.

This is then validated in a similar way to the domain but in an
additive fashion allowing either domain or email matching to validate the user.

**Alternative Option:**
- I considered replacing domain validation or adding a new option for a
  regex but felt this met the use cases I have more cleanly.