### PR TITLE
Add -prompt flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following configuration is supported:
 |-domain|string|Comma separated list of email domains to allow|
 |-lifetime|int|Session length in seconds (default 43200)|
 |-url-path|string|Callback URL (default "_oauth")|
+|-prompt|string|Space separated list of [OpenID prompt options](https://developers.google.com/identity/protocols/OpenIDConnect#prompt)|
 
 Configuration can also be supplied as environment variables (use upper case and swap `-`'s for `_`'s e.g. `-client-id` becomes `CLIENT_ID`)
 

--- a/forwardauth.go
+++ b/forwardauth.go
@@ -40,6 +40,8 @@ type ForwardAuth struct {
   Domain []string
 
   Direct bool
+
+  Prompt string
 }
 
 // Request Validation
@@ -114,7 +116,9 @@ func (f *ForwardAuth) GetLoginURL(r *http.Request, nonce string) string {
   q.Set("client_id", fw.ClientId)
   q.Set("response_type", "code")
   q.Set("scope", fw.Scope)
-  // q.Set("approval_prompt", fw.ClientId)
+  if fw.Prompt != "" {
+    q.Set("prompt", fw.Prompt)
+  }
   q.Set("redirect_uri", f.redirectUri(r))
   q.Set("state", state)
 

--- a/forwardauth_test.go
+++ b/forwardauth_test.go
@@ -146,6 +146,7 @@ func TestGetLoginURL(t *testing.T) {
       Host: "test.com",
       Path: "/auth",
     },
+    Prompt: "consent select_account",
   }
 
   // Check url
@@ -170,6 +171,7 @@ func TestGetLoginURL(t *testing.T) {
     "redirect_uri": []string{"http://example.com/_oauth"},
     "response_type": []string{"code"},
     "scope": []string{"scopetest"},
+    "prompt": []string{"consent select_account"},
     "state": []string{"nonce:http://example.com/hello"},
   }
   if !reflect.DeepEqual(qs, expectedQs) {

--- a/main.go
+++ b/main.go
@@ -142,6 +142,7 @@ func main() {
   cookieSecure := flag.Bool("cookie-secure", true, "Use secure cookies")
   domainList := flag.String("domain", "", "Comma separated list of email domains to allow")
   direct := flag.Bool("direct", false, "Run in direct mode (use own hostname as oppose to X-Forwarded-Host, used for testing/development)")
+  prompt := flag.String("prompt", "", "Space separated list of OpenID prompt options")
 
   flag.Parse()
 
@@ -216,6 +217,8 @@ func main() {
     Domain: domain,
 
     Direct: *direct,
+
+    Prompt: *prompt,
   }
 
   // Attach handler


### PR DESCRIPTION
Add the -prompt flag to be able to customize the OpenID "prompt" field (https://developers.google.com/identity/protocols/OpenIDConnect#prompt).

This is useful when you always want to prompt the Google consent OAuth page.
In this case, you just have to pass the "-prompt consent" flag.

We have this usecase because we use traefik-forward-auth to secure some sensitive backoffice tools.
Thus, we set a short lifetime duration (30 min), and enforce the "-prompt consent" flag.