### PR TITLE
Include X-Forwarded-Prefix in returnURL

### DIFF
--- a/forwardauth.go
+++ b/forwardauth.go
@@ -199,9 +199,10 @@ func (f *ForwardAuth) redirectBase(r *http.Request) string {
 
 // Return url
 func (f *ForwardAuth) returnUrl(r *http.Request) string {
+	prefix := r.Header.Get("X-Forwarded-Prefix")
 	path := r.Header.Get("X-Forwarded-Uri")
 
-	return fmt.Sprintf("%s%s", f.redirectBase(r), path)
+	return fmt.Sprintf("%s%s%s", f.redirectBase(r), prefix, path)
 }
 
 // Get oauth redirect uri

--- a/forwardauth.go
+++ b/forwardauth.go
@@ -199,6 +199,12 @@ func (f *ForwardAuth) redirectBase(r *http.Request) string {
 
 // Return url
 func (f *ForwardAuth) returnUrl(r *http.Request) string {
+	replacedPath := r.Header.Get("X-Replaced-Path")
+	if replacedPath != "" {
+		// request-modifier and path-related matchers cannot be used at the same time
+		// so if X-Replaced-Path is set that means X-Forwarded-Prefix et al. are not
+		return fmt.Sprintf("%s%s", f.redirectBase(r), replacedPath)
+	}
 	prefix := r.Header.Get("X-Forwarded-Prefix")
 	path := r.Header.Get("X-Forwarded-Uri")
 

--- a/forwardauth_test.go
+++ b/forwardauth_test.go
@@ -243,11 +243,12 @@ func TestGetLoginURL(t *testing.T) {
 	//
 	// With Auth URL + cookie domain, but from different domain
 	// - will not use auth host
+	// Also piggybacking a test for X-Replaced-Path
 	//
 	r, _ = http.NewRequest("GET", "http://another.com", nil)
 	r.Header.Add("X-Forwarded-Proto", "http")
 	r.Header.Add("X-Forwarded-Host", "another.com")
-	r.Header.Add("X-Forwarded-Prefix", "/stripped-prefix")
+	r.Header.Add("X-Replaced-Path", "/replaced-path/")
 	r.Header.Add("X-Forwarded-Uri", "/hello")
 
 	// Check url
@@ -272,7 +273,7 @@ func TestGetLoginURL(t *testing.T) {
 		"redirect_uri":  []string{"http://another.com/_oauth"},
 		"response_type": []string{"code"},
 		"scope":         []string{"scopetest"},
-		"state":         []string{"nonce:http://another.com/stripped-prefix/hello"},
+		"state":         []string{"nonce:http://another.com/replaced-path/"},
 	}
 	qsDiff(expectedQs, qs)
 	if !reflect.DeepEqual(qs, expectedQs) {

--- a/forwardauth_test.go
+++ b/forwardauth_test.go
@@ -100,6 +100,7 @@ func TestGetLoginURL(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://example.com", nil)
 	r.Header.Add("X-Forwarded-Proto", "http")
 	r.Header.Add("X-Forwarded-Host", "example.com")
+	r.Header.Add("X-Forwarded-Prefix", "/stripped-prefix")
 	r.Header.Add("X-Forwarded-Uri", "/hello")
 
 	fw = &ForwardAuth{
@@ -136,7 +137,7 @@ func TestGetLoginURL(t *testing.T) {
 		"redirect_uri":  []string{"http://example.com/_oauth"},
 		"response_type": []string{"code"},
 		"scope":         []string{"scopetest"},
-		"state":         []string{"nonce:http://example.com/hello"},
+		"state":         []string{"nonce:http://example.com/stripped-prefix/hello"},
 	}
 	if !reflect.DeepEqual(qs, expectedQs) {
 		t.Error("Incorrect login query string:")
@@ -184,7 +185,7 @@ func TestGetLoginURL(t *testing.T) {
 		"response_type": []string{"code"},
 		"scope":         []string{"scopetest"},
 		"prompt":        []string{"consent select_account"},
-		"state":         []string{"nonce:http://example.com/hello"},
+		"state":         []string{"nonce:http://example.com/stripped-prefix/hello"},
 	}
 	if !reflect.DeepEqual(qs, expectedQs) {
 		t.Error("Incorrect login query string:")
@@ -231,7 +232,7 @@ func TestGetLoginURL(t *testing.T) {
 		"redirect_uri":  []string{"http://auth.example.com/_oauth"},
 		"response_type": []string{"code"},
 		"scope":         []string{"scopetest"},
-		"state":         []string{"nonce:http://example.com/hello"},
+		"state":         []string{"nonce:http://example.com/stripped-prefix/hello"},
 	}
 	qsDiff(expectedQs, qs)
 	if !reflect.DeepEqual(qs, expectedQs) {
@@ -246,6 +247,7 @@ func TestGetLoginURL(t *testing.T) {
 	r, _ = http.NewRequest("GET", "http://another.com", nil)
 	r.Header.Add("X-Forwarded-Proto", "http")
 	r.Header.Add("X-Forwarded-Host", "another.com")
+	r.Header.Add("X-Forwarded-Prefix", "/stripped-prefix")
 	r.Header.Add("X-Forwarded-Uri", "/hello")
 
 	// Check url
@@ -270,7 +272,7 @@ func TestGetLoginURL(t *testing.T) {
 		"redirect_uri":  []string{"http://another.com/_oauth"},
 		"response_type": []string{"code"},
 		"scope":         []string{"scopetest"},
-		"state":         []string{"nonce:http://another.com/hello"},
+		"state":         []string{"nonce:http://another.com/stripped-prefix/hello"},
 	}
 	qsDiff(expectedQs, qs)
 	if !reflect.DeepEqual(qs, expectedQs) {


### PR DESCRIPTION
When using the PathPrefixStrip frontend rule in traefik X-Forwarded-Uri does not contain the true request URI, but the one where the path prefix has already been stripped.
Including the titular header in returnUrl() ensures that the user is returned to the correct URI when returning from the auth site.

See https://docs.traefik.io/basics/#path-matcher-usage-guidelines for more details. I'm not really sure what happens when you do a regexp rewrite though and how to handle that.

This solves my use-case though and works like a charm :-)

I also updated the tests.