### PR TITLE
Use X-Forwarded-Prefix if present to handle PathPrefixStrip traefik rules

### DIFF
--- a/internal/auth.go
+++ b/internal/auth.go
@@ -133,9 +133,14 @@ func redirectBase(r *http.Request) string {
 
 // Return url
 func returnUrl(r *http.Request) string {
+	replacedPath := r.Header.Get("X-Replaced-Path")
+	if replacedPath != "" {
+		return fmt.Sprintf("%s%s", redirectBase(r), replacedPath)
+	}
 	path := r.Header.Get("X-Forwarded-Uri")
+	prefix := r.Header.Get(("X-Forwarded-Prefix"))
 
-	return fmt.Sprintf("%s%s", redirectBase(r), path)
+	return fmt.Sprintf("%s%s%s", redirectBase(r), prefix, path)
 }
 
 // Get oauth redirect uri

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -137,10 +138,13 @@ func returnUrl(r *http.Request) string {
 	if replacedPath != "" {
 		return fmt.Sprintf("%s%s", redirectBase(r), replacedPath)
 	}
-	path := r.Header.Get("X-Forwarded-Uri")
+	uri := r.Header.Get("X-Forwarded-Uri")
 	prefix := r.Header.Get(("X-Forwarded-Prefix"))
-
-	return fmt.Sprintf("%s%s%s", redirectBase(r), prefix, path)
+	p := path.Join(prefix, uri)
+	if strings.HasSuffix(uri, "/") {
+		p += "/"
+	}
+	return fmt.Sprintf("%s%s", redirectBase(r), p)
 }
 
 // Get oauth redirect uri

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -141,9 +141,6 @@ func returnUrl(r *http.Request) string {
 	uri := r.Header.Get("X-Forwarded-Uri")
 	prefix := r.Header.Get(("X-Forwarded-Prefix"))
 	p := path.Join(prefix, uri)
-	if strings.HasSuffix(uri, "/") {
-		p += "/"
-	}
 	return fmt.Sprintf("%s%s", redirectBase(r), p)
 }
 

--- a/internal/server.go
+++ b/internal/server.go
@@ -60,17 +60,17 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 	r.Method = r.Header.Get("X-Forwarded-Method")
 	r.Host = r.Header.Get("X-Forwarded-Host")
 
-	path := r.Header.Get("X-Forwarded-Uri")
-	r.URL, _ = url.Parse(path)
-
-	prefix := r.Header.Get("X-Forwarded-Prefix")
-	if prefix != "" {
-		// Use X-Forwarded-Prefix if present (PathPrefixStrip traefik rules)
-		r.URL, _ = url.Parse(fmt.Sprintf("%s%s", prefix, path))
-	}
 	// Use X-Replaced-Path if present (Traefik Modifiers)
 	if r.Header.Get("X-Replaced-Path") != "" {
 		r.URL, _ = url.Parse(r.Header.Get("X-Replaced-Path"))
+	} else {
+		path := r.Header.Get("X-Forwarded-Uri")
+		r.URL, _ = url.Parse(path)
+		prefix := r.Header.Get("X-Forwarded-Prefix")
+		if prefix != "" {
+			// Use X-Forwarded-Prefix if present (PathPrefixStrip traefik rules)
+			r.URL, _ = url.Parse(fmt.Sprintf("%s%s", prefix, path))
+		}
 	}
 
 	// Pass to mux

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -428,6 +428,18 @@ func TestServerRoutePath(t *testing.T) {
 	req = newDefaultHttpRequest("/private/path")
 	res, _ = doHttpRequest(req, nil)
 	assert.Equal(200, res.StatusCode, "request matching allow rule should be allowed")
+
+	// Should allow matching request
+	req = newDefaultHttpRequest("/path")
+	req.Header.Add("X-Forwarded-Prefix", "/private")
+	res, _ = doHttpRequest(req, nil)
+	assert.Equal(200, res.StatusCode, "request matching allow rule should be allowed")
+
+	// Should allow matching request
+	req = newDefaultHttpRequest("/replaced/path")
+	req.Header.Add("X-Replaced-Path", "/private/path")
+	res, _ = doHttpRequest(req, nil)
+	assert.Equal(200, res.StatusCode, "request matching allow rule should be allowed")
 }
 
 func TestServerRouteQuery(t *testing.T) {


### PR DESCRIPTION
When Traefik is configured with `PathPrefixStrip` rules, the `X-Forwarded-Uri` is equal to `/` instead of the prefix.
This fix use the `X-Forwarded-Prefix` Header when present to allow correct redirection and rules matching.