### PR TITLE
Fixed documentation for recommended tag on docker hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A minimal forward authentication service that provides Google oauth based login 
 
 ## Releases
 
-We recommend using the `2` tag on docker hub.
+We recommend using the `v2.0.0` tag on docker hub.
 
 You can also use the latest incremental releases found on [docker hub](https://hub.docker.com/r/thomseddon/traefik-forward-auth/tags) and [github](https://github.com/thomseddon/traefik-forward-auth/releases).
 


### PR DESCRIPTION
The recommended tag doesn't actually exists