### PR TITLE
Default X-Forwarded-User email for allowed routes

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -213,6 +213,8 @@ func (c *Config) parseUnknownFlag(option string, arg flags.SplitArgument, args [
 			rule.Rule = val
 		case "provider":
 			rule.Provider = val
+		case "email":
+			rule.Email = val
 		default:
 			return args, fmt.Errorf("inavlid route param: %v", option)
 		}
@@ -269,6 +271,7 @@ type Rule struct {
 	Action   string
 	Rule     string
 	Provider string
+	Email 	 string
 }
 
 func NewRule() *Rule {

--- a/test/config0
+++ b/test/config0
@@ -3,3 +3,4 @@ csrf-cookie-name=inicsrfcookiename
 url-path=one
 rule.1.action=allow
 rule.1.rule=PathPrefix(`/one`)
+rule.1.email=test@example.com


### PR DESCRIPTION
Senario: 

We have a grafana instance on which we have setup [Auth Proxy](https://grafana.com/docs/auth/auth-proxy/), that means that we cannot log in to Grafana normally but the Header with the user email in is matched by grafana and that way we are being authenticated. This works perfectly

Then we have some screens showing grafana dashboards where nobody can login via tha Google Promt. As grafana expects a user from the header we need to be able to send a default user email specified in the rules so that grafana can authenticate. 

What do you think of the concept? I will expand and fix the PR if you thinks the concept i usable for others
