### PR TITLE
Open redirect in oauth path

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/containous/traefik/pkg/rules"
 	"github.com/sirupsen/logrus"
+
+	"strings"
 )
 
 type Server struct {
@@ -143,6 +145,14 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		user, err := GetUser(token)
 		if err != nil {
 			logger.Errorf("Error getting user: %s", err)
+			return
+		}
+
+		//Validate redirect
+		allowedHostForRedirect := redirectBase(r)
+		if !strings.HasPrefix(redirect+"/", allowedHostForRedirect+"/") {
+			logger.Errorf("Redirection %v does not match the redirectBase", redirect)
+			http.Error(w, "Not authorized", 401)
 			return
 		}
 

--- a/internal/server.go
+++ b/internal/server.go
@@ -149,8 +149,8 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		}
 
 		//Validate redirect
-		allowedHostForRedirect := redirectBase(r)
-		if !strings.HasPrefix(redirect+"/", allowedHostForRedirect+"/") {
+		redirectBaseUseToForgeStatePrameter := redirectBase(r)
+		if !strings.HasPrefix(redirect+"/", redirectBaseUseToForgeStatePrameter+"/") {
 			logger.Errorf("Redirection %v does not match the redirectBase", redirect)
 			http.Error(w, "Not authorized", 401)
 			return

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -130,21 +130,21 @@ func TestServerAuthCallback(t *testing.T) {
 	assert.Equal(401, res.StatusCode, "auth callback without cookie shouldn't be authorised")
 
 	// Should catch invalid csrf cookie
-	req = newDefaultHttpRequest("/_oauth?state=12345678901234567890123456789012:http://redirect")
+	req = newDefaultHttpRequest("/_oauth?state=12345678901234567890123456789012:http://example.com")
 	c := MakeCSRFCookie(req, "nononononononononononononononono")
 	res, _ = doHttpRequest(req, c)
 	assert.Equal(401, res.StatusCode, "auth callback with invalid cookie shouldn't be authorised")
 
 	// Should redirect valid request
-	req = newDefaultHttpRequest("/_oauth?state=12345678901234567890123456789012:http://redirect")
+	req = newDefaultHttpRequest("/_oauth?state=12345678901234567890123456789012:http://example.com/redirect")
 	c = MakeCSRFCookie(req, "12345678901234567890123456789012")
 	res, _ = doHttpRequest(req, c)
 	assert.Equal(307, res.StatusCode, "valid auth callback should be allowed")
 
 	fwd, _ := res.Location()
 	assert.Equal("http", fwd.Scheme, "valid request should be redirected to return url")
-	assert.Equal("redirect", fwd.Host, "valid request should be redirected to return url")
-	assert.Equal("", fwd.Path, "valid request should be redirected to return url")
+	assert.Equal("example.com", fwd.Host, "valid request should be redirected to return url")
+	assert.Equal("/redirect", fwd.Path, "valid request should be redirected to return url")
 }
 
 func TestServerDefaultAction(t *testing.T) {


### PR DESCRIPTION
The state is used in order to redirect user after authentication.
It is composed of crsf_cookie:redirect_url. 
redirect_url is not validated and could lead to an open redirect ([CWE-601: URL Redirection to Untrusted Site ('Open Redirect')](https://cwe.mitre.org/data/definitions/601.html)) in case of xss forging the crsf cookie in the website protected by the authentication.
A prevention could be to use a whitelist: https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md

Looking at the code, the state parameter of the auth cannot be on another domain and scheme than the redirect parameter in state.

So I added the verification of the redirect parameter based on how the state parameter.