### PR TITLE
Add GitHub Provider / Refactor Providers

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ The authenticated user is set in the `X-Forwarded-User` header, to pass this on 
 
 #### Overlay Mode
 
-Overlay is the default operation mode, in this mode the authorisation endpoint is overlayed onto any domain. By default the `/_oauth` path is used, this can be customised using the `url-path` option.
+Overlay is the default operation mode, in this mode the authorisation endpoint is overlaid onto any domain. By default the `/_oauth` path is used, this can be customised using the `url-path` option.
 
 The user flow will be:
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/containous/flaeg v1.4.1 // indirect
 	github.com/containous/mux v0.0.0-20181024131434-c33f32e26898 // indirect
 	github.com/containous/traefik v2.0.0-alpha2+incompatible
+	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/go-acme/lego v2.5.0+incompatible // indirect
 	github.com/go-kit/kit v0.8.0 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
@@ -21,6 +22,7 @@ require (
 	github.com/miekg/dns v1.1.8 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.4.1
 	github.com/stretchr/objx v0.2.0 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/vulcand/predicate v1.1.0 // indirect
 	golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd // indirect
 	golang.org/x/net v0.0.0-20190420063019-afa5a82059c6 // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-acme/lego v2.4.0+incompatible h1:+BTLUfLtDc5qQauyiTCXH6lupEUOCvXyGlEjdeU0YQI=
 github.com/go-acme/lego v2.4.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
+github.com/go-acme/lego v2.5.0+incompatible h1:5fNN9yRQfv8ymH3DSsxla+4aYeQt2IgfZqHKVnK8f0s=
 github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
 github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1qxKWjE/Bpp46npY=
@@ -10,6 +11,8 @@ github.com/containous/mux v0.0.0-20181024131434-c33f32e26898 h1:1srn9voikJGofblB
 github.com/containous/mux v0.0.0-20181024131434-c33f32e26898/go.mod h1:z8WW7n06n8/1xF9Jl9WmuDeZuHAhfL+bwarNjsciwwg=
 github.com/containous/traefik v2.0.0-alpha2+incompatible h1:5RS6mUAOPQCy1jAmcmxLj2nChIcs3fKuxZxH9AF6ih8=
 github.com/containous/traefik v2.0.0-alpha2+incompatible/go.mod h1:epDRqge3JzKOhlSWzOpNYEEKXmM6yfN5tPzDGKk3ljo=
+github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom8DBE9so9EBsM=
+github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -19,6 +22,7 @@ github.com/go-acme/lego v2.5.0+incompatible h1:5fNN9yRQfv8ymH3DSsxla+4aYeQt2IgfZ
 github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
 github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gravitational/trace v0.0.0-20190409171327-f30095ced5ff h1:xL/fJdlTJL6R/6Qk2tPu3EP1NsXgap9hXLvxKH0Ytko=
@@ -46,6 +50,8 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 h1:J9b7z+QKAmPf4YLrFg6oQUotqHQeUNWwkvo7jZp1GLU=
+github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
@@ -69,12 +75,17 @@ golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a h1:Igim7XhdOpBnWPuYJ70XcN
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd h1:sMHc2rZHuzQmrbVoSpt9HgerkXPyIeCSO6k0zUMGfFk=
 golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190420063019-afa5a82059c6 h1:HdqqaWmYAUI7/dmByKKEw+yxDksGSo+9GjkUc9Zp34E=
 golang.org/x/net v0.0.0-20190420063019-afa5a82059c6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -85,6 +96,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -71,8 +71,20 @@ func ValidateCookie(r *http.Request, c *http.Cookie) (string, error) {
 }
 
 // Validate email
-func ValidateEmail(email string) bool {
+func ValidateEmail(authMethod string) bool {
 	found := false
+
+	values, err := url.ParseQuery(authMethod)
+
+	if err != nil {
+		return false
+	}
+
+	email := values.Get("email")
+	if email == "" {
+		return false
+	}
+
 	if len(config.Whitelist) > 0 {
 		for _, whitelist := range config.Whitelist {
 			if email == whitelist {

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -273,7 +273,7 @@ func cookieSignature(r *http.Request, email, expires string) string {
 	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
 }
 
-// Get cookie expirary
+// Get cookie expiry
 func cookieExpiry() time.Time {
 	return time.Now().Local().Add(config.Lifetime)
 }

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -23,33 +23,34 @@ func ValidateCookie(r *http.Request, c *http.Cookie) (string, error) {
 	parts := strings.Split(c.Value, "|")
 
 	if len(parts) != 3 {
-		return "", errors.New("Invalid cookie format")
+		return "", errors.New("invalid cookie format")
 	}
 
 	mac, err := base64.URLEncoding.DecodeString(parts[0])
 	if err != nil {
-		return "", errors.New("Unable to decode cookie mac")
+		return "", errors.New("unable to decode cookie mac")
 	}
 
 	expectedSignature := cookieSignature(r, parts[2], parts[1])
 	expected, err := base64.URLEncoding.DecodeString(expectedSignature)
 	if err != nil {
-		return "", errors.New("Unable to generate mac")
+		return "", errors.New("unable to generate mac")
 	}
 
 	// Valid token?
 	if !hmac.Equal(mac, expected) {
-		return "", errors.New("Invalid cookie mac")
+		return "", errors.New("invalid cookie mac")
 	}
 
 	expires, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return "", errors.New("Unable to parse cookie expiry")
+		return "", errors.New("unable to parse cookie expiry")
 	}
 
 	// Has it expired?
-	if time.Unix(expires, 0).Before(time.Now()) {
-		return "", errors.New("Cookie has expired")
+	now := time.Now()
+	if time.Unix(expires, 0).Before(now) {
+		return "", errors.New("cookie has expired")
 	}
 
 	// Looks valid
@@ -242,13 +243,12 @@ func redirectBase(r *http.Request) string {
 	host := r.Header.Get("X-Forwarded-Host")
 	port := r.Header.Get("X-Forwarded-Port")
 
-	if port != "" {
-		port, err := strconv.Atoi(port)
-		if err == nil && port >= 1 && port <= 65535 {
-			return fmt.Sprintf("%s://%s:%d", proto, host, port)
-		}
-	}
-
+   if port != "" {
+		   port, err := strconv.Atoi(port)
+		   if err == nil && port >= 1 && port <= 65535 {
+				   return fmt.Sprintf("%s://%s:%d", proto, host, port)
+		   }
+   }
 	return fmt.Sprintf("%s://%s", proto, host)
 }
 
@@ -266,11 +266,11 @@ func redirectUri(r *http.Request) string {
 		port := r.Header.Get("X-Forwarded-Port")
 
 		if port != "" {
-			port, err := strconv.Atoi(port)
-			log.Info("Got port: ", port)
-			if err == nil && port >= 1 && port <= 65535 {
-				return fmt.Sprintf("%s://%s:%d%s", proto, config.AuthHost, port, config.Path)
-			}
+			   port, err := strconv.Atoi(port)
+			   log.Info("Got port: ", port)
+			   if err == nil && port >= 1 && port <= 65535 {
+					   return fmt.Sprintf("%s://%s:%d%s", proto, config.AuthHost, port, config.Path)
+			   }
 		}
 		return fmt.Sprintf("%s://%s%s", proto, config.AuthHost, config.Path)
 	}

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -83,6 +83,134 @@ func ValidateEmail(email string) bool {
 
 // Utility methods
 
+// TODO: test
+
+// TODO: Split google tests out
+// func TestAuthGetLoginURL(t *testing.T) {
+// 	assert := assert.New(t)
+// 	google := Google{
+// 		ClientId:     "idtest",
+// 		ClientSecret: "sectest",
+// 		Scope:        "scopetest",
+// 		Prompt:       "consent select_account",
+// 		LoginURL: &url.URL{
+// 			Scheme: "https",
+// 			Host:   "test.com",
+// 			Path:   "/auth",
+// 		},
+// 	}
+
+// 	config, _ = tfa.NewConfig([]string{})
+// 	config.Providers.Google = google
+
+// 	r, _ := http.NewRequest("GET", "http://example.com", nil)
+// 	r.Header.Add("X-Forwarded-Proto", "http")
+// 	r.Header.Add("X-Forwarded-Host", "example.com")
+// 	r.Header.Add("X-Forwarded-Uri", "/hello")
+
+// 	// Check url
+// 	uri, err := url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
+
+// 	// Check query string
+// 	qs := uri.Query()
+// 	expectedQs := url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://example.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"prompt":        []string{"consent select_account"},
+// 		"state":         []string{"nonce:http://example.com/hello"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
+
+// 	//
+// 	// With Auth URL but no matching cookie domain
+// 	// - will not use auth host
+// 	//
+// 	config, _ = tfa.NewConfig([]string{})
+// 	config.AuthHost = "auth.example.com"
+// 	config.Providers.Google = google
+
+// 	// Check url
+// 	uri, err = url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
+
+// 	// Check query string
+// 	qs = uri.Query()
+// 	expectedQs = url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://example.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"prompt":        []string{"consent select_account"},
+// 		"state":         []string{"nonce:http://example.com/hello"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
+
+// 	//
+// 	// With correct Auth URL + cookie domain
+// 	//
+// 	config, _ = tfa.NewConfig([]string{})
+// 	config.AuthHost = "auth.example.com"
+// 	config.CookieDomains = []CookieDomain{*NewCookieDomain("example.com")}
+// 	config.Providers.Google = google
+
+// 	// Check url
+// 	uri, err = url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
+
+// 	// Check query string
+// 	qs = uri.Query()
+// 	expectedQs = url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://auth.example.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"state":         []string{"nonce:http://example.com/hello"},
+// 		"prompt":        []string{"consent select_account"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
+
+// 	//
+// 	// With Auth URL + cookie domain, but from different domain
+// 	// - will not use auth host
+// 	//
+// 	r, _ = http.NewRequest("GET", "http://another.com", nil)
+// 	r.Header.Add("X-Forwarded-Proto", "http")
+// 	r.Header.Add("X-Forwarded-Host", "another.com")
+// 	r.Header.Add("X-Forwarded-Uri", "/hello")
+
+// 	// Check url
+// 	uri, err = url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
+
+// 	// Check query string
+// 	qs = uri.Query()
+// 	expectedQs = url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://another.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"state":         []string{"nonce:http://another.com/hello"},
+// 		"prompt":        []string{"consent select_account"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
+// }
+//
+
 // Get the redirect base
 func redirectBase(r *http.Request) string {
 	proto := r.Header.Get("X-Forwarded-Proto")

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -32,24 +32,24 @@ func TestAuthValidateCookie(t *testing.T) {
 	c.Value = ""
 	_, err := ValidateCookie(r, c)
 	if assert.Error(err) {
-		assert.Equal("invalid cookie format", err.Error())
+		assert.Equal(ERRORS_INVALID_COOKIE_FORMAT, err.Error())
 	}
 	c.Value = "1|2"
 	_, err = ValidateCookie(r, c)
 	if assert.Error(err) {
-		assert.Equal("invalid cookie format", err.Error())
+		assert.Equal(ERRORS_INVALID_COOKIE_FORMAT, err.Error())
 	}
 	c.Value = "1|2|3|4"
 	_, err = ValidateCookie(r, c)
 	if assert.Error(err) {
-		assert.Equal("invalid cookie format", err.Error())
+		assert.Equal(ERRORS_INVALID_COOKIE_FORMAT, err.Error())
 	}
 
 	// Should catch invalid mac
 	c.Value = "MQ==|2|3"
 	_, err = ValidateCookie(r, c)
 	if assert.Error(err) {
-		assert.Equal("invalid cookie mac", err.Error())
+		assert.Equal(ERRORS_INVALID_COOKIE_MAC, err.Error())
 	}
 
 	// Should catch expired
@@ -59,7 +59,7 @@ func TestAuthValidateCookie(t *testing.T) {
 	c = MakeCookie(r, v)
 	_, err = ValidateCookie(r, c)
 	if assert.Error(err) {
-		assert.Equal("cookie has expired", err.Error())
+		assert.Equal(ERRORS_COOKIE_HAS_EXPIRED, err.Error())
 	}
 
 	// Should accept valid cookie
@@ -317,13 +317,13 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 	valid, _, _, err := ValidateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
-		assert.Equal("Invalid CSRF cookie value", err.Error())
+		assert.Equal(ERRORS_INVALID_CSRF_COOKIE_VALUE, err.Error())
 	}
 	c.Value = "123456789012345678901234567890123"
 	valid, _, _, err = ValidateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
-		assert.Equal("Invalid CSRF cookie value", err.Error())
+		assert.Equal(ERRORS_INVALID_CSRF_COOKIE_VALUE, err.Error())
 	}
 
 	// Should require valid state
@@ -332,7 +332,7 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 	valid, _, _, err = ValidateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
-		assert.Equal("Invalid CSRF state value", err.Error())
+		assert.Equal(ERRORS_INVALID_CSRF_STATE_VALUE, err.Error())
 	}
 
 	// Should require provider
@@ -341,7 +341,7 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 	valid, _, _, err = ValidateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
-		assert.Equal("Invalid CSRF state format", err.Error())
+		assert.Equal(ERRORS_INVALID_CSRF_FORMAT, err.Error())
 	}
 
 	// Should allow valid state

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/thomseddon/traefik-forward-auth/internal/provider"
+	// "github.com/thomseddon/traefik-forward-auth/internal/provider"
 )
 
 /**
@@ -96,129 +97,129 @@ func TestAuthValidateEmail(t *testing.T) {
 }
 
 // TODO: Split google tests out
-func TestAuthGetLoginURL(t *testing.T) {
-	assert := assert.New(t)
-	google := provider.Google{
-		ClientId:     "idtest",
-		ClientSecret: "sectest",
-		Scope:        "scopetest",
-		Prompt:       "consent select_account",
-		LoginURL: &url.URL{
-			Scheme: "https",
-			Host:   "test.com",
-			Path:   "/auth",
-		},
-	}
+// func TestAuthGetLoginURL(t *testing.T) {
+// 	assert := assert.New(t)
+// 	google := provider.Google{
+// 		ClientId:     "idtest",
+// 		ClientSecret: "sectest",
+// 		Scope:        "scopetest",
+// 		Prompt:       "consent select_account",
+// 		LoginURL: &url.URL{
+// 			Scheme: "https",
+// 			Host:   "test.com",
+// 			Path:   "/auth",
+// 		},
+// 	}
 
-	config, _ = NewConfig([]string{})
-	config.Providers.Google = google
+// 	config, _ = NewConfig([]string{})
+// 	config.Providers.Google = google
 
-	r, _ := http.NewRequest("GET", "http://example.com", nil)
-	r.Header.Add("X-Forwarded-Proto", "http")
-	r.Header.Add("X-Forwarded-Host", "example.com")
-	r.Header.Add("X-Forwarded-Uri", "/hello")
+// 	r, _ := http.NewRequest("GET", "http://example.com", nil)
+// 	r.Header.Add("X-Forwarded-Proto", "http")
+// 	r.Header.Add("X-Forwarded-Host", "example.com")
+// 	r.Header.Add("X-Forwarded-Uri", "/hello")
 
-	// Check url
-	uri, err := url.Parse(GetLoginURL(r, "nonce"))
-	assert.Nil(err)
-	assert.Equal("https", uri.Scheme)
-	assert.Equal("test.com", uri.Host)
-	assert.Equal("/auth", uri.Path)
+// 	// Check url
+// 	uri, err := url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
 
-	// Check query string
-	qs := uri.Query()
-	expectedQs := url.Values{
-		"client_id":     []string{"idtest"},
-		"redirect_uri":  []string{"http://example.com/_oauth"},
-		"response_type": []string{"code"},
-		"scope":         []string{"scopetest"},
-		"prompt":        []string{"consent select_account"},
-		"state":         []string{"nonce:http://example.com/hello"},
-	}
-	assert.Equal(expectedQs, qs)
+// 	// Check query string
+// 	qs := uri.Query()
+// 	expectedQs := url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://example.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"prompt":        []string{"consent select_account"},
+// 		"state":         []string{"nonce:http://example.com/hello"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
 
-	//
-	// With Auth URL but no matching cookie domain
-	// - will not use auth host
-	//
-	config, _ = NewConfig([]string{})
-	config.AuthHost = "auth.example.com"
-	config.Providers.Google = google
+// 	//
+// 	// With Auth URL but no matching cookie domain
+// 	// - will not use auth host
+// 	//
+// 	config, _ = NewConfig([]string{})
+// 	config.AuthHost = "auth.example.com"
+// 	config.Providers.Google = google
 
-	// Check url
-	uri, err = url.Parse(GetLoginURL(r, "nonce"))
-	assert.Nil(err)
-	assert.Equal("https", uri.Scheme)
-	assert.Equal("test.com", uri.Host)
-	assert.Equal("/auth", uri.Path)
+// 	// Check url
+// 	uri, err = url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
 
-	// Check query string
-	qs = uri.Query()
-	expectedQs = url.Values{
-		"client_id":     []string{"idtest"},
-		"redirect_uri":  []string{"http://example.com/_oauth"},
-		"response_type": []string{"code"},
-		"scope":         []string{"scopetest"},
-		"prompt":        []string{"consent select_account"},
-		"state":         []string{"nonce:http://example.com/hello"},
-	}
-	assert.Equal(expectedQs, qs)
+// 	// Check query string
+// 	qs = uri.Query()
+// 	expectedQs = url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://example.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"prompt":        []string{"consent select_account"},
+// 		"state":         []string{"nonce:http://example.com/hello"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
 
-	//
-	// With correct Auth URL + cookie domain
-	//
-	config, _ = NewConfig([]string{})
-	config.AuthHost = "auth.example.com"
-	config.CookieDomains = []CookieDomain{*NewCookieDomain("example.com")}
-	config.Providers.Google = google
+// 	//
+// 	// With correct Auth URL + cookie domain
+// 	//
+// 	config, _ = NewConfig([]string{})
+// 	config.AuthHost = "auth.example.com"
+// 	config.CookieDomains = []CookieDomain{*NewCookieDomain("example.com")}
+// 	config.Providers.Google = google
 
-	// Check url
-	uri, err = url.Parse(GetLoginURL(r, "nonce"))
-	assert.Nil(err)
-	assert.Equal("https", uri.Scheme)
-	assert.Equal("test.com", uri.Host)
-	assert.Equal("/auth", uri.Path)
+// 	// Check url
+// 	uri, err = url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
 
-	// Check query string
-	qs = uri.Query()
-	expectedQs = url.Values{
-		"client_id":     []string{"idtest"},
-		"redirect_uri":  []string{"http://auth.example.com/_oauth"},
-		"response_type": []string{"code"},
-		"scope":         []string{"scopetest"},
-		"state":         []string{"nonce:http://example.com/hello"},
-		"prompt":        []string{"consent select_account"},
-	}
-	assert.Equal(expectedQs, qs)
+// 	// Check query string
+// 	qs = uri.Query()
+// 	expectedQs = url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://auth.example.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"state":         []string{"nonce:http://example.com/hello"},
+// 		"prompt":        []string{"consent select_account"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
 
-	//
-	// With Auth URL + cookie domain, but from different domain
-	// - will not use auth host
-	//
-	r, _ = http.NewRequest("GET", "http://another.com", nil)
-	r.Header.Add("X-Forwarded-Proto", "http")
-	r.Header.Add("X-Forwarded-Host", "another.com")
-	r.Header.Add("X-Forwarded-Uri", "/hello")
+// 	//
+// 	// With Auth URL + cookie domain, but from different domain
+// 	// - will not use auth host
+// 	//
+// 	r, _ = http.NewRequest("GET", "http://another.com", nil)
+// 	r.Header.Add("X-Forwarded-Proto", "http")
+// 	r.Header.Add("X-Forwarded-Host", "another.com")
+// 	r.Header.Add("X-Forwarded-Uri", "/hello")
 
-	// Check url
-	uri, err = url.Parse(GetLoginURL(r, "nonce"))
-	assert.Nil(err)
-	assert.Equal("https", uri.Scheme)
-	assert.Equal("test.com", uri.Host)
-	assert.Equal("/auth", uri.Path)
+// 	// Check url
+// 	uri, err = url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
 
-	// Check query string
-	qs = uri.Query()
-	expectedQs = url.Values{
-		"client_id":     []string{"idtest"},
-		"redirect_uri":  []string{"http://another.com/_oauth"},
-		"response_type": []string{"code"},
-		"scope":         []string{"scopetest"},
-		"state":         []string{"nonce:http://another.com/hello"},
-		"prompt":        []string{"consent select_account"},
-	}
-	assert.Equal(expectedQs, qs)
-}
+// 	// Check query string
+// 	qs = uri.Query()
+// 	expectedQs = url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://another.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"state":         []string{"nonce:http://another.com/hello"},
+// 		"prompt":        []string{"consent select_account"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
+// }
 
 // TODO
 // func TestAuthExchangeCode(t *testing.T) {
@@ -304,13 +305,13 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 	// Should require 32 char string
 	r := newCsrfRequest("")
 	c.Value = ""
-	valid, _, err := ValidateCSRFCookie(r, c)
+	valid, _, _, err := ValidateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
 		assert.Equal("Invalid CSRF cookie value", err.Error())
 	}
 	c.Value = "123456789012345678901234567890123"
-	valid, _, err = ValidateCSRFCookie(r, c)
+	valid, _, _, err = ValidateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
 		assert.Equal("Invalid CSRF cookie value", err.Error())
@@ -319,19 +320,57 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 	// Should require valid state
 	r = newCsrfRequest("12345678901234567890123456789012:")
 	c.Value = "12345678901234567890123456789012"
-	valid, _, err = ValidateCSRFCookie(r, c)
+	valid, _, _, err = ValidateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
 		assert.Equal("Invalid CSRF state value", err.Error())
 	}
 
-	// Should allow valid state
+	// Should require provider
 	r = newCsrfRequest("12345678901234567890123456789012:99")
 	c.Value = "12345678901234567890123456789012"
-	valid, state, err := ValidateCSRFCookie(r, c)
+	valid, _, _, err = ValidateCSRFCookie(r, c)
+	assert.False(valid)
+	if assert.Error(err) {
+		assert.Equal("Invalid CSRF state format", err.Error())
+	}
+
+	// Should allow valid state
+	r = newCsrfRequest("12345678901234567890123456789012:p99:url123")
+	c.Value = "12345678901234567890123456789012"
+	valid, provider, redirect, err := ValidateCSRFCookie(r, c)
 	assert.True(valid, "valid request should return valid")
 	assert.Nil(err, "valid request should not return an error")
-	assert.Equal("99", state, "valid request should return correct state")
+	assert.Equal("p99", provider, "valid request should return correct provider")
+	assert.Equal("url123", redirect, "valid request should return correct redirect")
+}
+
+func TestMakeState(t *testing.T) {
+	assert := assert.New(t)
+	p := provider.Google{
+		ClientId:     "idtest",
+		ClientSecret: "sectest",
+		Scope:        "scopetest",
+		Prompt:       "consent select_account",
+		LoginURL: &url.URL{
+			Scheme: "https",
+			Host:   "test.com",
+			Path:   "/auth",
+		},
+	}
+
+	config, _ = NewConfig([]string{})
+	config.Providers.Google = p
+
+	r, _ := http.NewRequest("GET", "http://example.com", nil)
+	r.Header.Add("X-Forwarded-Proto", "http")
+	r.Header.Add("X-Forwarded-Host", "example.com")
+	r.Header.Add("X-Forwarded-Uri", "/hello")
+
+	state := MakeState(r, &p, "nonce")
+	assert.Equal("nonce:google:http://example.com/hello", state)
+
+	// TODO: Test with other providers
 }
 
 func TestAuthNonce(t *testing.T) {

--- a/internal/config.go
+++ b/internal/config.go
@@ -248,7 +248,7 @@ func convertLegacyToIni(name string) (io.Reader, error) {
 func (c *Config) Validate() {
 	// Check for show stopper errors
 	if len(c.Secret) == 0 {
-		log.Fatal("\"secret\" option must be set.")
+		log.Fatal("\"secret\" option must be set")
 	}
 
 	// Validate default provider
@@ -257,21 +257,9 @@ func (c *Config) Validate() {
 		log.Fatal(err)
 	}
 
-	// Check rules
-	// TODO: decide
+	// Check rules (validates the rule and the rule provider)
 	for _, rule := range c.Rules {
 		err = rule.Validate(c)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	for _, r := range c.Rules {
-		if r.Action != "auth" && r.Action != "allow" {
-			log.Fatal("invalid rule action, must be \"auth\" or \"allow\"")
-		}
-
-		err = c.validateProvider(r.Provider)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -283,11 +271,13 @@ func (c Config) String() string {
 	return string(jsonConf)
 }
 
-// GetProvider returns the provider of the given name. Ret
+// GetProvider returns the provider of the given name
 func (c *Config) GetProvider(name string) (provider.Provider, error) {
 	switch name {
 	case "google":
-		return &config.Providers.Google, nil
+		return &c.Providers.Google, nil
+	case "oidc":
+		return &c.Providers.OIDC, nil
 	}
 
 	return nil, fmt.Errorf("Unknown provider: %s", name)
@@ -298,7 +288,7 @@ func (c *Config) GetProvider(name string) (provider.Provider, error) {
 func (c *Config) GetConfiguredProvider(name string) (provider.Provider, error) {
 	// Check the provider has been configured
 	if !c.providerConfigured(name) {
-		return nil, errors.New("Unconfigured provider")
+		return nil, fmt.Errorf("Unconfigured provider: %s", name)
 	}
 
 	return c.GetProvider(name)
@@ -306,7 +296,7 @@ func (c *Config) GetConfiguredProvider(name string) (provider.Provider, error) {
 
 func (c *Config) providerConfigured(name string) bool {
 	// Check default provider
-	if name == config.DefaultProvider {
+	if name == c.DefaultProvider {
 		return true
 	}
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	CookieDomainsLegacy CookieDomains `long:"cookie-domains" env:"COOKIE_DOMAINS" description:"DEPRECATED - Use \"cookie-domain\""`
 	CookieSecretLegacy  string        `long:"cookie-secret" env:"COOKIE_SECRET" description:"DEPRECATED - Use \"secret\""  json:"-"`
 	CookieSecureLegacy  string        `long:"cookie-secure" env:"COOKIE_SECURE" description:"DEPRECATED - Use \"insecure-cookie\""`
-	ClientIdLegacy      string        `long:"client-id" env:"CLIENT_ID" group:"DEPs" description:"DEPRECATED - Use \"providers.google.client-id\""`
+	ClientIdLegacy      string        `long:"client-id" env:"CLIENT_ID" description:"DEPRECATED - Use \"providers.google.client-id\""`
 	ClientSecretLegacy  string        `long:"client-secret" env:"CLIENT_SECRET" description:"DEPRECATED - Use \"providers.google.client-id\""  json:"-"`
 	PromptLegacy        string        `long:"prompt" env:"PROMPT" description:"DEPRECATED - Use \"providers.google.prompt\""`
 }
@@ -161,7 +161,7 @@ func (c *Config) parseFlags(args []string) error {
 
 	_, err := p.ParseArgs(args)
 	if err != nil {
-		return handlFlagError(err)
+		return handleFlagError(err)
 	}
 
 	return nil
@@ -214,7 +214,7 @@ func (c *Config) parseUnknownFlag(option string, arg flags.SplitArgument, args [
 		case "provider":
 			rule.Provider = val
 		default:
-			return args, fmt.Errorf("inavlid route param: %v", option)
+			return args, fmt.Errorf("invalid route param: %v", option)
 		}
 	} else {
 		return args, fmt.Errorf("unknown flag: %v", option)
@@ -223,7 +223,7 @@ func (c *Config) parseUnknownFlag(option string, arg flags.SplitArgument, args [
 	return args, nil
 }
 
-func handlFlagError(err error) error {
+func handleFlagError(err error) error {
 	flagsErr, ok := err.(*flags.Error)
 	if ok && flagsErr.Type == flags.ErrHelp {
 		// Library has just printed cli help

--- a/internal/config.go
+++ b/internal/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	LifetimeString  int                  `long:"lifetime" env:"LIFETIME" default:"43200" description:"Lifetime in seconds"`
 	Path            string               `long:"url-path" env:"URL_PATH" default:"/_oauth" description:"Callback URL Path"`
 	SecretString    string               `long:"secret" env:"SECRET" description:"Secret used for signing (required)" json:"-"`
+	Teams			CommaSeparatedList   `long:"teams" env:"TEAMS" description:"Only allow given team, can be set multiple times"`
 	Whitelist       CommaSeparatedList   `long:"whitelist" env:"WHITELIST" description:"Only allow given email addresses, can be set multiple times"`
 
 	Providers provider.Providers `group:"providers" namespace:"providers" env-namespace:"PROVIDERS"`
@@ -102,6 +103,11 @@ func NewConfig(args []string) (Config, error) {
 					Scheme: "https",
 					Host:   "api.github.com",
 					Path:   "/user",
+				},
+				TeamsURL: &url.URL{
+					Scheme: "https",
+					Host:   "api.github.com",
+					Path:   "/user/teams",
 				},
 			},
 		},

--- a/internal/config.go
+++ b/internal/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	CookieName      string               `long:"cookie-name" env:"COOKIE_NAME" default:"_forward_auth" description:"Cookie Name"`
 	CSRFCookieName  string               `long:"csrf-cookie-name" env:"CSRF_COOKIE_NAME" default:"_forward_auth_csrf" description:"CSRF Cookie Name"`
 	DefaultAction   string               `long:"default-action" env:"DEFAULT_ACTION" default:"auth" choice:"auth" choice:"allow" description:"Default action"`
-	DefaultProvider string               `long:"default-provider" env:"DEFAULT_PROVIDER" default:"google" choice:"google" choice:"odic" description:"Default provider"`
+	DefaultProvider string               `long:"default-provider" env:"DEFAULT_PROVIDER" default:"google" choice:"google" choice:"odic" choice:"github" description:"Default provider"`
 	Domains         CommaSeparatedList   `long:"domain" env:"DOMAIN" description:"Only allow given email domains, can be set multiple times"`
 	LifetimeString  int                  `long:"lifetime" env:"LIFETIME" default:"43200" description:"Lifetime in seconds"`
 	Path            string               `long:"url-path" env:"URL_PATH" default:"/_oauth" description:"Callback URL Path"`
@@ -85,6 +85,23 @@ func NewConfig(args []string) (Config, error) {
 					Scheme: "https",
 					Host:   "www.googleapis.com",
 					Path:   "/oauth2/v2/userinfo",
+				},
+			},
+			GitHub: provider.GitHub{
+				LoginURL: &url.URL{
+					Scheme: "https",
+					Host:   "github.com",
+					Path:   "/login/oauth/authorize",
+				},
+				TokenURL: &url.URL{
+					Scheme: "https",
+					Host:   "github.com",
+					Path:   "/login/oauth/access_token",
+				},
+				UserURL:  &url.URL{
+					Scheme: "https",
+					Host:   "api.github.com",
+					Path:   "/user",
 				},
 			},
 		},
@@ -278,6 +295,8 @@ func (c *Config) GetProvider(name string) (provider.Provider, error) {
 		return &c.Providers.Google, nil
 	case "oidc":
 		return &c.Providers.OIDC, nil
+	case "github":
+		return &c.Providers.GitHub, nil
 	}
 
 	return nil, fmt.Errorf("Unknown provider: %s", name)

--- a/internal/config.go
+++ b/internal/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	LifetimeString  int                  `long:"lifetime" env:"LIFETIME" default:"43200" description:"Lifetime in seconds"`
 	Path            string               `long:"url-path" env:"URL_PATH" default:"/_oauth" description:"Callback URL Path"`
 	SecretString    string               `long:"secret" env:"SECRET" description:"Secret used for signing (required)" json:"-"`
-	Teams			CommaSeparatedList   `long:"teams" env:"TEAMS" description:"Only allow given team, can be set multiple times"`
+	Teams           CommaSeparatedList   `long:"teams" env:"TEAMS" description:"Only allow given team, can be set multiple times"`
 	Whitelist       CommaSeparatedList   `long:"whitelist" env:"WHITELIST" description:"Only allow given email addresses, can be set multiple times"`
 
 	Providers provider.Providers `group:"providers" namespace:"providers" env-namespace:"PROVIDERS"`
@@ -99,7 +99,7 @@ func NewConfig(args []string) (Config, error) {
 					Host:   "github.com",
 					Path:   "/login/oauth/access_token",
 				},
-				UserURL:  &url.URL{
+				UserURL: &url.URL{
 					Scheme: "https",
 					Host:   "api.github.com",
 					Path:   "/user",

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -273,7 +273,7 @@ func TestConfigParseEnvironmentBackwardsCompatability(t *testing.T) {
 
 	// "cookie-secure" used to be a standard go bool flag that could take
 	// true, TRUE, 1, false, FALSE, 0 etc. values.
-	// Here we're checking that format is still suppoted
+	// Here we're checking that format is still supported
 	assert.Equal("false", c.CookieSecureLegacy)
 	assert.True(c.InsecureCookie, "--cookie-secure=false should set insecure-cookie true")
 

--- a/internal/log.go
+++ b/internal/log.go
@@ -6,9 +6,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log logrus.FieldLogger
+var log *logrus.Logger
 
-func NewDefaultLogger() logrus.FieldLogger {
+func NewDefaultLogger() *logrus.Logger {
 	// Setup logger
 	log = logrus.StandardLogger()
 	logrus.SetOutput(os.Stdout)

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type GitHub struct {
+	ClientId     string `long:"client-id" env:"CLIENT_ID" description:"Client ID"`
+	ClientSecret string `long:"client-secret" env:"CLIENT_SECRET" description:"Client Secret" json:"-"`
+	Scope        string `long:"scopes" env:"SCOPES" description:"Oauth Scopes"`
+	Prompt       string `long:"prompt" env:"PROMPT" description:"Space separated list of OpenID prompt options"`
+
+	LoginURL *url.URL
+	TokenURL *url.URL
+	UserURL  *url.URL
+}
+
+func (g *GitHub) Name() string {
+	return "github"
+}
+
+func (g *GitHub) Validate() error {
+	if g.ClientId == "" || g.ClientSecret == "" {
+		return errors.New("providers.github.client-id, providers.github.client-secret must be set")
+	}
+	return nil
+}
+
+func (g *GitHub) GetLoginURL(redirectUri, state string) string {
+	q := url.Values{}
+	q.Set("client_id", g.ClientId)
+	q.Set("redirect_uri", redirectUri)
+	q.Set("scope", strings.Replace(g.Scope, ",", " ",-1))
+	if g.Prompt != "" {
+		q.Set("prompt", g.Prompt)
+	}
+	q.Set("state", state)
+
+	var u url.URL
+	u = *g.LoginURL
+	u.RawQuery = q.Encode()
+
+	return u.String()
+}
+
+func (g *GitHub) ExchangeCode(redirectUri, code string) (string, error) {
+	form := url.Values{}
+	form.Set("client_id", g.ClientId)
+	form.Set("client_secret", g.ClientSecret)
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectUri)
+
+	res, err := http.PostForm(g.TokenURL.String(), form)
+	if err != nil {
+		return "", err
+	}
+
+	var token Token
+	defer res.Body.Close()
+	err = json.NewDecoder(res.Body).Decode(&token)
+
+	return token.Token, err
+}
+
+func (g *GitHub) GetUser(token string) (User, error) {
+	var user User
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", g.UserURL.String(), nil)
+	if err != nil {
+		return user, err
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("token %s", token))
+	res, err := client.Do(req)
+	if err != nil {
+		return user, err
+	}
+
+	defer res.Body.Close()
+	err = json.NewDecoder(res.Body).Decode(&user)
+
+	return user, err
+}

--- a/internal/provider/google.go
+++ b/internal/provider/google.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -16,6 +17,17 @@ type Google struct {
 	LoginURL *url.URL
 	TokenURL *url.URL
 	UserURL  *url.URL
+}
+
+func (g *Google) Name() string {
+	return "google"
+}
+
+func (g *Google) Validate() error {
+	if g.ClientId == "" || g.ClientSecret == "" {
+		return errors.New("providers.google.client-id, providers.google.client-secret must be set")
+	}
+	return nil
 }
 
 func (g *Google) GetLoginURL(redirectUri, state string) string {

--- a/internal/provider/google_test.go
+++ b/internal/provider/google_test.go
@@ -85,7 +85,7 @@ func TestGoogleExchangeCode(t *testing.T) {
 	assert.Equal("123456789", token)
 }
 
-func TestGoogleGetUser(t *testing.T) {
+func TestGoogleGetAuth(t *testing.T) {
 	assert := assert.New(t)
 	p := Google{
 		ClientId:     "idtest",
@@ -106,11 +106,13 @@ func TestGoogleGetUser(t *testing.T) {
 	userURL, _ := url.Parse(userServer.URL)
 	p.UserURL = userURL
 
-	user, err := p.GetUser("123456789")
+	authMethod, err := p.GetAuthMethod("123456789")
 	assert.Nil(err)
 
-  assert.Equal("1", user.Id)
-  assert.Equal("example@example.com", user.Email)
-  assert.True(user.Verified)
-  assert.Equal("example.com", user.Hd)
+	assert.Nil(err)
+
+	assert.Equal("1", authMethod.Get("user"))
+	assert.Equal("example@example.com", authMethod.Get("email"))
+	assert.True(authMethod.Get("verified") == "true")
+	assert.Equal("example.com", authMethod.Get("hd"))
 }

--- a/internal/provider/google_test.go
+++ b/internal/provider/google_test.go
@@ -1,40 +1,12 @@
 package provider
 
 import (
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// Utilities
-
-type TokenServerHandler struct{}
-
-func (t *TokenServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	body, _ := ioutil.ReadAll(r.Body)
-	if r.Method == "POST" &&
-			string(body) == "client_id=idtest&client_secret=sectest&code=code&grant_type=authorization_code&redirect_uri=http%3A%2F%2Fexample.com%2F_oauth" {
-		fmt.Fprint(w, `{"access_token":"123456789"}`)
-	} else {
-		fmt.Fprint(w, `TokenServerHandler received bad request`)
-	}
-}
-
-type UserServerHandler struct{}
-
-func (t *UserServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, `{
-    "id":"1",
-    "email":"example@example.com",
-    "verified_email":true,
-    "hd":"example.com"
-  }`)
-}
 
 // Tests
 

--- a/internal/provider/google_test.go
+++ b/internal/provider/google_test.go
@@ -1,0 +1,136 @@
+package provider
+
+// import (
+// 	"net/http"
+// 	"net/url"
+// 	"testing"
+
+// 	"github.com/stretchr/testify/assert"
+// 	// tfa "github.com/thomseddon/traefik-forward-auth/internal"
+// )
+
+// TODO: Split google tests out
+// func TestAuthGetLoginURL(t *testing.T) {
+// 	assert := assert.New(t)
+// 	google := Google{
+// 		ClientId:     "idtest",
+// 		ClientSecret: "sectest",
+// 		Scope:        "scopetest",
+// 		Prompt:       "consent select_account",
+// 		LoginURL: &url.URL{
+// 			Scheme: "https",
+// 			Host:   "test.com",
+// 			Path:   "/auth",
+// 		},
+// 	}
+
+// 	config, _ = tfa.NewConfig([]string{})
+// 	config.Providers.Google = google
+
+// 	r, _ := http.NewRequest("GET", "http://example.com", nil)
+// 	r.Header.Add("X-Forwarded-Proto", "http")
+// 	r.Header.Add("X-Forwarded-Host", "example.com")
+// 	r.Header.Add("X-Forwarded-Uri", "/hello")
+
+// 	// Check url
+// 	uri, err := url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
+
+// 	// Check query string
+// 	qs := uri.Query()
+// 	expectedQs := url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://example.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"prompt":        []string{"consent select_account"},
+// 		"state":         []string{"nonce:http://example.com/hello"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
+
+// 	//
+// 	// With Auth URL but no matching cookie domain
+// 	// - will not use auth host
+// 	//
+// 	config, _ = tfa.NewConfig([]string{})
+// 	config.AuthHost = "auth.example.com"
+// 	config.Providers.Google = google
+
+// 	// Check url
+// 	uri, err = url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
+
+// 	// Check query string
+// 	qs = uri.Query()
+// 	expectedQs = url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://example.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"prompt":        []string{"consent select_account"},
+// 		"state":         []string{"nonce:http://example.com/hello"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
+
+// 	//
+// 	// With correct Auth URL + cookie domain
+// 	//
+// 	config, _ = tfa.NewConfig([]string{})
+// 	config.AuthHost = "auth.example.com"
+// 	config.CookieDomains = []CookieDomain{*NewCookieDomain("example.com")}
+// 	config.Providers.Google = google
+
+// 	// Check url
+// 	uri, err = url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
+
+// 	// Check query string
+// 	qs = uri.Query()
+// 	expectedQs = url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://auth.example.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"state":         []string{"nonce:http://example.com/hello"},
+// 		"prompt":        []string{"consent select_account"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
+
+// 	//
+// 	// With Auth URL + cookie domain, but from different domain
+// 	// - will not use auth host
+// 	//
+// 	r, _ = http.NewRequest("GET", "http://another.com", nil)
+// 	r.Header.Add("X-Forwarded-Proto", "http")
+// 	r.Header.Add("X-Forwarded-Host", "another.com")
+// 	r.Header.Add("X-Forwarded-Uri", "/hello")
+
+// 	// Check url
+// 	uri, err = url.Parse(GetLoginURL(r, "nonce"))
+// 	assert.Nil(err)
+// 	assert.Equal("https", uri.Scheme)
+// 	assert.Equal("test.com", uri.Host)
+// 	assert.Equal("/auth", uri.Path)
+
+// 	// Check query string
+// 	qs = uri.Query()
+// 	expectedQs = url.Values{
+// 		"client_id":     []string{"idtest"},
+// 		"redirect_uri":  []string{"http://another.com/_oauth"},
+// 		"response_type": []string{"code"},
+// 		"scope":         []string{"scopetest"},
+// 		"state":         []string{"nonce:http://another.com/hello"},
+// 		"prompt":        []string{"consent select_account"},
+// 	}
+// 	assert.Equal(expectedQs, qs)
+// }
+//

--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"net/url"
+)
+
+type OIDC struct {
+	ClientId     string `long:"client-id" env:"CLIENT_ID" description:"Client ID"`
+	ClientSecret string `long:"client-secret" env:"CLIENT_SECRET" description:"Client Secret" json:"-"`
+	Scope        string
+	Prompt       string `long:"prompt" env:"PROMPT" description:"Space separated list of OpenID prompt options"`
+
+	LoginURL *url.URL
+	TokenURL *url.URL
+	UserURL  *url.URL
+}
+
+func (o *OIDC) Name() string {
+	return "oidc"
+}
+
+func (o *OIDC) Validate() error {
+	// TODO
+	return nil
+}
+
+func (o *OIDC) GetLoginURL(redirectUri, state string) string {
+	return "http://oidc.com"
+	// q := url.Values{}
+	// q.Set("client_id", g.ClientId)
+	// q.Set("response_type", "code")
+	// q.Set("scope", g.Scope)
+	// if g.Prompt != "" {
+	// 	q.Set("prompt", g.Prompt)
+	// }
+	// q.Set("redirect_uri", redirectUri)
+	// q.Set("state", state)
+
+	// var u url.URL
+	// u = *g.LoginURL
+	// u.RawQuery = q.Encode()
+
+	// return u.String()
+}
+
+func (o *OIDC) ExchangeCode(redirectUri, code string) (string, error) {
+	return "token", nil
+	// form := url.Values{}
+	// form.Set("client_id", g.ClientId)
+	// form.Set("client_secret", g.ClientSecret)
+	// form.Set("grant_type", "authorization_code")
+	// form.Set("redirect_uri", redirectUri)
+	// form.Set("code", code)
+
+	// res, err := http.PostForm(g.TokenURL.String(), form)
+	// if err != nil {
+	// 	return "", err
+	// }
+
+	// var token Token
+	// defer res.Body.Close()
+	// err = json.NewDecoder(res.Body).Decode(&token)
+
+	// return token.Token, err
+}
+
+func (o *OIDC) GetUser(token string) (User, error) {
+	var user User
+	return user, nil
+
+	// client := &http.Client{}
+	// req, err := http.NewRequest("GET", g.UserURL.String(), nil)
+	// if err != nil {
+	// 	return user, err
+	// }
+
+	// req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// res, err := client.Do(req)
+	// if err != nil {
+	// 	return user, err
+	// }
+
+	// defer res.Body.Close()
+	// err = json.NewDecoder(res.Body).Decode(&user)
+
+	// return user, err
+}

--- a/internal/provider/oidc_test.go
+++ b/internal/provider/oidc_test.go
@@ -1,0 +1,173 @@
+package provider
+
+import (
+	// "fmt"
+	// "io/ioutil"
+	// "net/http"
+	// "net/http/httptest"
+	"net/url"
+	"testing"
+
+	"golang.org/x/oauth2"
+	"github.com/stretchr/testify/assert"
+)
+// Utilities
+
+// type IssuerServerHandler struct{}
+
+// func NewIssuerServer() (*httptest.Server, *url.URL) {
+// 	handler := &IssuerServerHandler{}
+// 	server := httptest.NewServer(handler)
+// 	URL, _ := url.Parse(server.URL)
+// 	return server, URL
+// }
+
+// func (t *IssuerServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+// 	// body, _ := ioutil.ReadAll(r.Body)
+// 	fmt.Fprint(w, `{"access_token":"123456789"}`)
+// 	// if r.Method == "POST" &&
+// 	// 		string(body) == "client_id=idtest&client_secret=sectest&code=code&grant_type=authorization_code&redirect_uri=http%3A%2F%2Fexample.com%2F_oauth" {
+// 	// 	fmt.Fprint(w, `{"access_token":"123456789"}`)
+// 	// } else {
+// 	// 	fmt.Fprint(w, `IssuerServerHandler received bad request`)
+// 	// }
+// }
+
+// Tests
+
+func TestOIDCName(t *testing.T) {
+	p := OIDC{}
+	assert.Equal(t, "oidc", p.Name())
+}
+
+func TestOIDCValidate(t *testing.T) {
+	assert := assert.New(t)
+	p := OIDC{}
+
+	err := p.Validate()
+	if assert.Error(err) {
+		assert.Equal("providers.oidc.issuer-url, providers.oidc.client-id, providers.oidc.client-secret must be set", err.Error())
+	}
+
+	// TODO: validate config object
+}
+
+func TestOIDCGetLoginURL(t *testing.T) {
+	assert := assert.New(t)
+
+	// Set up token server
+	tokenServer, tokenURL := NewTokenServer(map[string]string{})
+	defer tokenServer.Close()
+
+	p := OIDC{
+		config: &oauth2.Config{
+			ClientID:     "idtest",
+			ClientSecret: "sectest",
+			Endpoint: oauth2.Endpoint{
+				AuthURL: tokenURL.String(),
+			},
+			Scopes: []string{"profile", "email"},
+		},
+	}
+
+	// Check url
+	uri, err := url.Parse(p.GetLoginURL("http://example.com/_oauth", "state"))
+	assert.Nil(err)
+	assert.Equal(tokenURL.Scheme, uri.Scheme)
+	assert.Equal(tokenURL.Host, uri.Host)
+	assert.Equal(tokenURL.Path, uri.Path)
+
+	// Check query string
+	qs := uri.Query()
+	expectedQs := url.Values{
+		"client_id":     []string{"idtest"},
+		"redirect_uri":  []string{"http://example.com/_oauth"},
+		"response_type": []string{"code"},
+		"scope":         []string{"profile email"},
+		"state":         []string{"state"},
+	}
+	assert.Equal(expectedQs, qs)
+}
+
+func TestOIDCExchangeCode(t *testing.T) {
+	assert := assert.New(t)
+
+	// Set up token server
+	tokenServer, tokenURL := NewTokenServer(map[string]string{
+		"code": "code",
+		"grant_type": "authorization_code",
+		"redirect_uri": "http://example.com/_oauth",
+	})
+	defer tokenServer.Close()
+
+	p := OIDC{
+		config: &oauth2.Config{
+			ClientID:     "idtest",
+			ClientSecret: "sectest",
+			Endpoint: oauth2.Endpoint{
+				TokenURL: tokenURL.String(),
+			},
+			Scopes: []string{"profile", "email"},
+		},
+	}
+
+	token, err := p.ExchangeCode("http://example.com/_oauth", "code")
+	assert.Nil(err)
+	assert.Equal("id_123456789", token)
+}
+
+func TestOIDCGetUser(t *testing.T) {
+	assert := assert.New(t)
+
+	// Set up token server
+	userServer, userURL := NewUserServer()
+	defer userServer.Close()
+
+	p := OIDC{
+		config: &oauth2.Config{
+			ClientID:     "idtest",
+			ClientSecret: "sectest",
+			Endpoint: oauth2.Endpoint{
+				TokenURL: userURL.String(),
+			},
+			Scopes: []string{"profile", "email"},
+		},
+	}
+
+	user, err := p.GetUser("123456789")
+	assert.Nil(err)
+
+  assert.Equal("1", user.Id)
+  assert.Equal("example@example.com", user.Email)
+  assert.True(user.Verified)
+	assert.Equal("example.com", user.Hd)
+	return
+
+	// assert := assert.New(t)
+	// p := OIDC{
+	// 	ClientId:     "idtest",
+	// 	ClientSecret: "sectest",
+	// 	Scope:        "scopetest",
+	// 	Prompt:       "consent select_account",
+	// 	LoginURL: &url.URL{
+	// 		Scheme: "https",
+	// 		Host:   "google.com",
+	// 		Path:   "/auth",
+	// 	},
+	// }
+
+	// // Setup user server
+	// userServerHandler := &UserServerHandler{}
+	// userServer := httptest.NewServer(userServerHandler)
+	// defer userServer.Close()
+	// userURL, _ := url.Parse(userServer.URL)
+	// p.UserURL = userURL
+
+	// user, err := p.GetUser("123456789")
+	// assert.Nil(err)
+
+  // assert.Equal("1", user.Id)
+  // assert.Equal("example@example.com", user.Email)
+  // assert.True(user.Verified)
+  // assert.Equal("example.com", user.Hd)
+}

--- a/internal/provider/oidc_test.go
+++ b/internal/provider/oidc_test.go
@@ -8,8 +8,8 @@ import (
 	"net/url"
 	"testing"
 
-	"golang.org/x/oauth2"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
 )
 // Utilities
 
@@ -116,7 +116,7 @@ func TestOIDCExchangeCode(t *testing.T) {
 	assert.Equal("id_123456789", token)
 }
 
-func TestOIDCGetUser(t *testing.T) {
+func TestOIDCGetAuth(t *testing.T) {
 	assert := assert.New(t)
 
 	// Set up token server
@@ -134,13 +134,13 @@ func TestOIDCGetUser(t *testing.T) {
 		},
 	}
 
-	user, err := p.GetUser("123456789")
+	authMethod, err := p.GetAuthMethod("123456789")
 	assert.Nil(err)
 
-  assert.Equal("1", user.Id)
-  assert.Equal("example@example.com", user.Email)
-  assert.True(user.Verified)
-	assert.Equal("example.com", user.Hd)
+  assert.Equal("1", authMethod.Get("id"))
+  assert.Equal("example@example.com", authMethod.Get("email"))
+  assert.True(authMethod.Get("verified") == "true")
+	assert.Equal("example.com", authMethod.Get("hd"))
 	return
 
 	// assert := assert.New(t)

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -1,5 +1,7 @@
 package provider
 
+import "net/url"
+
 type Providers struct {
 	Google Google `group:"Google Provider" namespace:"google" env-namespace:"GOOGLE"`
 	GitHub GitHub `group:"Github Provider" namespace:"github" env-namespace:"GITHUB"`
@@ -10,8 +12,8 @@ type Provider interface {
 	Name() string
 	GetLoginURL(redirectUri, state string) string
 	ExchangeCode(redirectUri, code string) (string, error)
-	GetUser(token string) (User, error)
 	Validate() error
+	GetAuthMethod(token string) (url.Values, error)
 }
 
 type Token struct {
@@ -22,5 +24,5 @@ type User struct {
 	Id       string `json:"id"`
 	Email    string `json:"email"`
 	Verified bool   `json:"verified_email"`
-	Hd       string `json:"hd"`
+	Hd       string `json:"hd"` // Domain
 }

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -2,6 +2,7 @@ package provider
 
 type Providers struct {
 	Google Google `group:"Google Provider" namespace:"google" env-namespace:"GOOGLE"`
+	GitHub GitHub `group:"Github Provider" namespace:"github" env-namespace:"GITHUB"`
 	OIDC   OIDC   `group:"ODIC Provider" namespace:"odic" env-namespace:"ODIC"`
 }
 

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -2,6 +2,15 @@ package provider
 
 type Providers struct {
 	Google Google `group:"Google Provider" namespace:"google" env-namespace:"GOOGLE"`
+	OIDC   OIDC   `group:"ODIC Provider" namespace:"odic" env-namespace:"ODIC"`
+}
+
+type Provider interface {
+	Name() string
+	GetLoginURL(redirectUri, state string) string
+	ExchangeCode(redirectUri, code string) (string, error)
+	GetUser(token string) (User, error)
+	Validate() error
 }
 
 type Token struct {

--- a/internal/provider/providers_test.go
+++ b/internal/provider/providers_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+)
+
+// Utilities
+
+type TokenServerHandler struct{
+	Body string
+}
+
+func NewTokenServer(params map[string]string) (*httptest.Server, *url.URL) {
+	var body string
+	if len(params) > 0 {
+		q := url.Values{}
+		for k, v := range params {
+			q.Set(k, v)
+		}
+		body = q.Encode()
+	} else {
+		body = ""
+	}
+
+	handler := &TokenServerHandler{
+		Body: body,
+	}
+
+	server := httptest.NewServer(handler)
+	URL, _ := url.Parse(server.URL)
+	return server, URL
+}
+
+func (t *TokenServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := ioutil.ReadAll(r.Body)
+	if r.Method == "POST" && (t.Body == "" || string(body) == t.Body) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"123456789","id_token":"id_123456789"}`)
+	} else {
+		http.Error(w, "Token server recieved bad request", http.StatusBadRequest)
+	}
+}
+
+type UserServerHandler struct{}
+
+func NewUserServer() (*httptest.Server, *url.URL) {
+	handler := &UserServerHandler{}
+	server := httptest.NewServer(handler)
+	URL, _ := url.Parse(server.URL)
+	return server, URL
+}
+
+func (t *UserServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := ioutil.ReadAll(r.Body)
+	fmt.Println((string(body)))
+	fmt.Fprint(w, `{
+    "id":"1",
+    "email":"example@example.com",
+    "verified_email":true,
+    "hd":"example.com"
+  }`)
+}

--- a/internal/provider/providers_test.go
+++ b/internal/provider/providers_test.go
@@ -56,7 +56,7 @@ func NewUserServer() (*httptest.Server, *url.URL) {
 
 func (t *UserServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	body, _ := ioutil.ReadAll(r.Body)
-	fmt.Println((string(body)))
+	fmt.Println(string(body))
 	fmt.Fprint(w, `{
     "id":"1",
     "email":"example@example.com",

--- a/internal/server.go
+++ b/internal/server.go
@@ -37,6 +37,7 @@ func (s *Server) buildRoutes() {
 	}
 
 	// Add callback handler
+	log.Info("config.Path=", config.Path)
 	s.router.Handle(config.Path, s.AuthCallbackHandler())
 
 	// Add a default handler
@@ -72,6 +73,7 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Logging setup
 		logger := s.logger(r, rule, "Authenticating request")
+		log.Info("ReqURL=", r.RequestURI)
 
 		// Get auth cookie
 		c, err := r.Cookie(config.CookieName)
@@ -180,7 +182,7 @@ func (s *Server) authRedirect(logger *logrus.Entry, w http.ResponseWriter, r *ht
 
 	// Set the CSRF cookie
 	http.SetCookie(w, MakeCSRFCookie(r, nonce))
-	logger.Debug("Set CSRF cookie and redirecting to google login")
+	logger.Debug("Set CSRF cookie and redirecting to provider's login")
 
 	// Forward them on
 	loginUrl := p.GetLoginURL(redirectUri(r), MakeState(r, p, nonce))

--- a/internal/server.go
+++ b/internal/server.go
@@ -92,8 +92,8 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 		// Validate cookie
 		authMethod, err := ValidateCookie(r, c)
 		if err != nil {
-			if err.Error() == "Cookie has expired" {
-				logger.Info("Cookie has expired")
+			if err.Error() == ERRORS_COOKIE_HAS_EXPIRED {
+				logger.Info(ERRORS_COOKIE_HAS_EXPIRED)
 				s.authRedirect(logger, w, r, p)
 			} else {
 				logger.Errorf("Invalid cookie: %v", err)

--- a/internal/server.go
+++ b/internal/server.go
@@ -38,13 +38,13 @@ func (s *Server) buildRoutes() {
 
 	// Add callback handler
 	// Callback Rule
-	r := NewRule()
+	/*r := NewRule()
 	r.Rule = "Host(`" + config.AuthHost + "`) && Path(`"+ config.Path +"`)"
 	r.Action = "allow"
 	fr := r.formattedRule()
 
-	logrus.Debug("FormattedRule=", fr)
-	s.router.AddRoute(fr, 1, s.AuthCallbackHandler())
+	logrus.Debug("FormattedRule=", fr)*/
+	s.router.Handle(config.Path, s.AuthCallbackHandler())
 
 	// Add a default handler
 	if config.DefaultAction == "allow" {
@@ -59,7 +59,7 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 	r.Method = r.Header.Get("X-Forwarded-Method")
 	r.Host = r.Header.Get("X-Forwarded-Host")
 	if r.Header.Get("X-Forwarded-Uri") != "" {
-		r.URL, _ = url.Parse(r.Header.Get("X-Forwarded-Uri"))
+		   r.URL, _ = url.Parse(r.Header.Get("X-Forwarded-Uri"))
 	}
 
 	// Pass to mux
@@ -130,6 +130,7 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 				return
 			}
 		}
+
 		// Valid request
 		logger.Debugf("Allowing valid request ")
 		w.Header().Set("X-Forwarded-User", authMethod)
@@ -182,14 +183,14 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		authMethod, err := p.GetAuthMethod(token)
 		if err != nil {
 			logger.Errorf("Error getting user: %s", err)
-			http.Error(w, "Service unavailable", 503)
+			//http.Error(w, "Service unavailable", 503)
 			return
 		}
 
 		// Generate cookie
 		http.SetCookie(w, MakeCookie(r, authMethod))
 		logger.WithFields(logrus.Fields{
-			"auth_method": authMethod,
+			"auth_kethod": authMethod,
 		}).Infof("Generated auth cookie")
 
 		// Redirect

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TODO:
-
 /**
  * Setup
  */
@@ -136,7 +134,7 @@ func TestServerAuthCallback(t *testing.T) {
 	assert.Equal(401, res.StatusCode, "auth callback with invalid cookie shouldn't be authorised")
 
 	// Should redirect valid request
-	req = newDefaultHttpRequest("/_oauth?state=12345678901234567890123456789012:http://redirect")
+	req = newDefaultHttpRequest("/_oauth?state=12345678901234567890123456789012:google:http://redirect")
 	c = MakeCSRFCookie(req, "12345678901234567890123456789012")
 	res, _ = doHttpRequest(req, c)
 	assert.Equal(307, res.StatusCode, "valid auth callback should be allowed")

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -105,6 +105,7 @@ func TestServerAuthHandlerValid(t *testing.T) {
 	req := newDefaultHttpRequest("/foo")
 	c := MakeCookie(req, generateTestAuthMethod("test@example.com"))
 	config.Domains = []string{}
+	config.Whitelist = []string{"test@example.com"}
 
 	res, _ := doHttpRequest(req, c)
 	assert.Equal(200, res.StatusCode, "valid request should be allowed")

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -53,7 +53,7 @@ func TestServerAuthHandlerInvalid(t *testing.T) {
 
 	// Should catch invalid cookie
 	req = newDefaultHttpRequest("/foo")
-	c := MakeCookie(req, "test@example.com")
+	c := MakeCookie(req, generateTestAuthMethod("test@example.com"))
 	parts = strings.Split(c.Value, "|")
 	c.Value = fmt.Sprintf("bad|%s|%s", parts[1], parts[2])
 
@@ -62,7 +62,7 @@ func TestServerAuthHandlerInvalid(t *testing.T) {
 
 	// Should validate email
 	req = newDefaultHttpRequest("/foo")
-	c = MakeCookie(req, "test@example.com")
+	c = MakeCookie(req, generateTestAuthMethod("test@example.com"))
 	config.Domains = []string{"test.com"}
 
 	res, _ = doHttpRequest(req, c)
@@ -77,7 +77,7 @@ func TestServerAuthHandlerExpired(t *testing.T) {
 
 	// Should redirect expired cookie
 	req := newDefaultHttpRequest("/foo")
-	c := MakeCookie(req, "test@example.com")
+	c := MakeCookie(req, generateTestAuthMethod("test@example.com"))
 	res, _ := doHttpRequest(req, c)
 	assert.Equal(307, res.StatusCode, "request with expired cookie should be redirected")
 
@@ -103,7 +103,7 @@ func TestServerAuthHandlerValid(t *testing.T) {
 
 	// Should allow valid request email
 	req := newDefaultHttpRequest("/foo")
-	c := MakeCookie(req, "test@example.com")
+	c := MakeCookie(req, generateTestAuthMethod("test@example.com"))
 	config.Domains = []string{}
 
 	res, _ := doHttpRequest(req, c)
@@ -112,7 +112,7 @@ func TestServerAuthHandlerValid(t *testing.T) {
 	// Should pass through user
 	users := res.Header["X-Forwarded-User"]
 	assert.Len(users, 1, "valid request should have X-Forwarded-User header")
-	assert.Equal([]string{"test@example.com"}, users, "X-Forwarded-User header should match user")
+	assert.Equal([]string{"email=test@example.com"}, users, "X-Forwarded-User header should match user")
 }
 
 func TestServerAuthCallback(t *testing.T) {

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -110,9 +110,9 @@ func TestServerAuthHandlerValid(t *testing.T) {
 	assert.Equal(200, res.StatusCode, "valid request should be allowed")
 
 	// Should pass through user
-	users := res.Header["X-Forwarded-User"]
-	assert.Len(users, 1, "valid request should have X-Forwarded-User header")
-	assert.Equal([]string{"email=test@example.com"}, users, "X-Forwarded-User header should match user")
+	authMethod := res.Header["X-Forwarded-User"]
+	assert.Len(authMethod, 1, "valid request should have X-Forwarded-User header")
+	assert.Equal([]string{"email=test%40example.com"}, authMethod, "X-Forwarded-User header should match user")
 }
 
 func TestServerAuthCallback(t *testing.T) {


### PR DESCRIPTION
This PR adds GitHub as an authentication provider,  
it also refactors a little bit the authentication mode and the content of the authentication cookie, so that we don't have to rely on the `User` struct anymore and we can easily implement other providers. Depending on the provider, the cookie gets read by and matched: GitHub for example uses the `Teams` config property to match the users team with the one stored in the `TEAMS` (comma separated) environment variable.  

This feature branch is based on the feature/multiple-providers branch, that's why a test is still failing...
  
I've also improved the request handling, because for some reason my Traefik 2.0 configuration wasn't working properly (I'm using Kubernetes CRD):

```yaml
apiVersion: traefik.containo.us/v1alpha1
kind: IngressRoute
metadata:
  name: minio-route
  namespace: default
spec:
  entryPoints:
    - https
  routes:
    - match: Host(`service.domain.tld`)
      kind: Rule
      priority: 12
      services:
        - name: my-svc
          port: 9001
      middlewares:
      - name: traefik-fwd-auth
  tls:
    certResolver: default
----
apiVersion: v1
kind: Service
metadata:
  name: traefik-fwd-auth
  namespace: kube-system
  labels:
    name: traefik-fwd-auth
spec:
  selector:
    k8s-app: traefik-fwd-auth
  ports:
    - name: http
      port: 4181
      targetPort: 4181
---
apiVersion: traefik.containo.us/v1alpha1
kind: Middleware
metadata:
  name: traefik-fwd-auth
  namespace: default
spec:
  forwardAuth:
    address: http://traefik-fwd-auth:4181
    authResponseHeaders:
    - X-Forwarded-User
    trustForwardHeader: false
---
apiVersion: traefik.containo.us/v1alpha1
kind: IngressRoute
metadata:
  name: traefik-fwd-auth-route
  namespace: kube-system
spec:
  entryPoints:
    - https
  routes:
    - match: Host(`auth.domain.tld`)
      kind: Rule
      priority: 12
      services:
        - name: traefik-fwd-auth
          port: 4181
  tls:
    certResolver: default
---
kind: Deployment
apiVersion: extensions/v1beta1
metadata:
  name: traefik-forward-auth
  namespace: kube-system
spec:
  replicas: 1
  selector:
    matchLabels:
      k8s-app: traefik-fwd-auth
      app: traefik-fwd-auth
  template:
    metadata:
      labels:
        k8s-app: traefik-fwd-auth
        app: traefik-fwd-auth
    spec:
      containers:
      - image: registry.tld/devops/traefik-forward-auth:latest
        imagePullPolicy: Always
        name: fwd-auth
        ports:
        - name: http
          containerPort: 4181
        env:
        - name: PROVIDERS_GITHUB_CLIENT_ID
          valueFrom:
            secretKeyRef:
              name: traefik-fwd-auth-gh
              key: CLIENT_ID
        - name: PROVIDERS_GITHUB_CLIENT_SECRET
          valueFrom:
            secretKeyRef:
              name: traefik-fwd-auth-gh
              key: CLIENT_SECRET
        - name: PROVIDERS_GITHUB_SCOPES
          value: read:org,user:email
        - name: DEFAULT_PROVIDER
          value: github
        - name: SECRET
          valueFrom:
            secretKeyRef:
              name: traefik-fwd-auth
              key: SECRET
        - name: LOG_LEVEL
          value: debug
        - name: AUTH_HOST
          value: auth.domain.tld
        - name: DOMAIN
          value: domain.tld
        - name: COOKIE_DOMAIN
          value: domain.tld
        - name: TEAMS
          value: "2833553"
      imagePullSecrets:
      - name: regcred
```