### PR TITLE
Implemented --disable-httponly-cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Application Options:
   --auth-host=                                          Single host to use when returning from 3rd party auth [$AUTH_HOST]
   --config=                                             Path to config file [$CONFIG]
   --cookie-domain=                                      Domain to set auth cookie on, can be set multiple times [$COOKIE_DOMAIN]
+  --disable-httponly-cookie=[false|true]                If true, flag HTTPOnly is not set on cookie [$DISABLE_HTTPONLY_COOKIE]
   --insecure-cookie                                     Use insecure cookies [$INSECURE_COOKIE]
   --cookie-name=                                        Cookie Name (default: _forward_auth) [$COOKIE_NAME]
   --csrf-cookie-name=                                   CSRF Cookie Name (default: _forward_auth_csrf) [$CSRF_COOKIE_NAME]
@@ -208,6 +209,10 @@ All options can be supplied in any of the following ways, in the following prece
 - `insecure-cookie`
 
    If you are not using HTTPS between the client and traefik, you will need to pass the `insecure-cookie` option which will mean the `Secure` attribute on the cookie will not be set.
+
+- `disable-httponly-cookie`
+
+   If true, flag HTTPOnly is not set on cookie.
 
 - `cookie-name`
 

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -137,7 +137,7 @@ func MakeCookie(r *http.Request, email string) *http.Cookie {
 		Value:    value,
 		Path:     "/",
 		Domain:   cookieDomain(r),
-		HttpOnly: true,
+		HttpOnly: !config.DisableHTTPOnlyCookie,
 		Secure:   !config.InsecureCookie,
 		Expires:  expires,
 	}
@@ -150,7 +150,7 @@ func MakeCSRFCookie(r *http.Request, nonce string) *http.Cookie {
 		Value:    nonce,
 		Path:     "/",
 		Domain:   csrfCookieDomain(r),
-		HttpOnly: true,
+		HttpOnly: !config.DisableHTTPOnlyCookie,
 		Secure:   !config.InsecureCookie,
 		Expires:  cookieExpiry(),
 	}
@@ -163,7 +163,7 @@ func ClearCSRFCookie(r *http.Request) *http.Cookie {
 		Value:    "",
 		Path:     "/",
 		Domain:   csrfCookieDomain(r),
-		HttpOnly: true,
+		HttpOnly: !config.DisableHTTPOnlyCookie,
 		Secure:   !config.InsecureCookie,
 		Expires:  time.Now().Local().Add(time.Hour * -1),
 	}

--- a/internal/config.go
+++ b/internal/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Config          func(s string) error `long:"config" env:"CONFIG" description:"Path to config file" json:"-"`
 	CookieDomains   []CookieDomain       `long:"cookie-domain" env:"COOKIE_DOMAIN" description:"Domain to set auth cookie on, can be set multiple times"`
 	InsecureCookie  bool                 `long:"insecure-cookie" env:"INSECURE_COOKIE" description:"Use insecure cookies"`
+	DisableHTTPOnlyCookie  bool          `long:"disable-httponly-cookie" env:"DISABLE_HTTPONLY_COOKIE" description:"If true, flag HTTPOnly is not set on cookie"`
 	CookieName      string               `long:"cookie-name" env:"COOKIE_NAME" default:"_forward_auth" description:"Cookie Name"`
 	CSRFCookieName  string               `long:"csrf-cookie-name" env:"CSRF_COOKIE_NAME" default:"_forward_auth_csrf" description:"CSRF Cookie Name"`
 	DefaultAction   string               `long:"default-action" env:"DEFAULT_ACTION" default:"auth" choice:"auth" choice:"allow" description:"Default action"`


### PR DESCRIPTION
The new option disables the HTTPOnly flag so that JS can access the cookie.
This might be a security risk, that's why it's enabled by default.
Only use it, if you know, what you're doing.