### PR TITLE
Update golang arm versions

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.13-alpine as builder
 
 # Setup
 RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.13-alpine as builder
 
 # Setup
 RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth


### PR DESCRIPTION
# What
Updates Golang version for arm builds

# Why
Current arm build gives the following error on dns lookups

```
time="2020-03-01T19:00:10Z" level=fatal msg="Get https://xxx/.well-known/openid-configuration: dial tcp: lookup thsp.auth0.com on [xxx%eth0]:53: dial udp [xxx%eth0]:53: connect: invalid argument"
```