### PR TITLE
Allow whitelist to take a username mapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Application Options:
   --lifetime=                                           Lifetime in seconds (default: 43200) [$LIFETIME]
   --url-path=                                           Callback URL Path (default: /_oauth) [$URL_PATH]
   --secret=                                             Secret used for signing (required) [$SECRET]
-  --whitelist=                                          Only allow given email addresses, can be set multiple times [$WHITELIST]
+  --whitelist=                                          Only allow given email addresses, can be set multiple times. Entries may be "email:username" to map emails to custom usernames [$WHITELIST]
   --rule.<name>.<param>=                                Rule definitions, param can be: "action", "rule" or "provider"
 
 Google Provider:
@@ -316,9 +316,13 @@ You can restrict who can login with the following parameters:
 
 Note, if you pass `whitelist` then only this is checked and `domain` is effectively ignored.
 
+The whitelist can contain entries on the form `thom@test.com:theuser`, which will cause the server to report `theuser` as the authenticated user, instead of the email address.
+
 ### Forwarded Headers
 
 The authenticated user is set in the `X-Forwarded-User` header, to pass this on add this to the `authResponseHeaders` config option in traefik, as shown [here](https://github.com/thomseddon/traefik-forward-auth/blob/master/examples/docker-compose-dev.yml).
+
+The user's email address is available in `X-Forwarded-Email`. If the `whitelist` config option is empty, or it doesn't contain explicit user names, the `X-Forwarded-User` and `X-Forwarded-Email` will be the same.
 
 ### Operation Modes
 

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -55,30 +55,28 @@ func ValidateCookie(r *http.Request, c *http.Cookie) (string, error) {
 	return parts[2], nil
 }
 
-// Validate email
-func ValidateEmail(email string) bool {
-	found := false
-	if len(config.Whitelist) > 0 {
-		for _, whitelist := range config.Whitelist {
-			if email == whitelist {
-				found = true
-			}
-		}
-	} else if len(config.Domains) > 0 {
+// ValidateEmail authorizes an email based on whitelists. Returns
+// whether the email is allowed access, and the preferred username.
+func ValidateEmail(email string) (bool, string) {
+	if len(config.Whitelist) != 0 {
+		username, found := config.Whitelist[email]
+		return found, username
+	}
+
+	if len(config.Domains) > 0 {
 		parts := strings.Split(email, "@")
 		if len(parts) < 2 {
-			return false
+			return false, ""
 		}
 		for _, domain := range config.Domains {
 			if domain == parts[1] {
-				found = true
+				return true, email
 			}
 		}
-	} else {
-		return true
+		return false, ""
 	}
 
-	return found
+	return true, email
 }
 
 // Utility methods

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -67,32 +67,33 @@ func TestAuthValidateEmail(t *testing.T) {
 	config, _ = NewConfig([]string{})
 
 	// Should allow any
-	v := ValidateEmail("test@test.com")
+	v, _ := ValidateEmail("test@test.com")
 	assert.True(v, "should allow any domain if email domain is not defined")
-	v = ValidateEmail("one@two.com")
+	v, _ = ValidateEmail("one@two.com")
 	assert.True(v, "should allow any domain if email domain is not defined")
 
 	// Should block non matching domain
 	config.Domains = []string{"test.com"}
-	v = ValidateEmail("one@two.com")
+	v, _ = ValidateEmail("one@two.com")
 	assert.False(v, "should not allow user from another domain")
 
 	// Should allow matching domain
 	config.Domains = []string{"test.com"}
-	v = ValidateEmail("test@test.com")
+	v, _ = ValidateEmail("test@test.com")
 	assert.True(v, "should allow user from allowed domain")
 
 	// Should block non whitelisted email address
 	config.Domains = []string{}
-	config.Whitelist = []string{"test@test.com"}
-	v = ValidateEmail("one@two.com")
+	config.Whitelist = map[string]string{"test@test.com": "testuser"}
+	v, _ = ValidateEmail("one@two.com")
 	assert.False(v, "should not allow user not in whitelist")
 
 	// Should allow matching whitelisted email address
 	config.Domains = []string{}
-	config.Whitelist = []string{"test@test.com"}
-	v = ValidateEmail("test@test.com")
+	config.Whitelist = map[string]string{"test@test.com": "testuser"}
+	v, user := ValidateEmail("test@test.com")
 	assert.True(v, "should allow user in whitelist")
+	assert.Equal("testuser", user, "should return the mapper username")
 }
 
 func TestRedirectUri(t *testing.T) {

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -115,7 +115,7 @@ func TestConfigFlagBackwardsCompatability(t *testing.T) {
 		"--domain=test2.com,example.org",
 		"--domain=another2.net",
 		"--whitelist=test3.com,example.org",
-		"--whitelist=another3.net",
+		"--whitelist=another3.net,test4@example.org:testuser4",
 	})
 	require.Nil(t, err)
 
@@ -130,7 +130,7 @@ func TestConfigFlagBackwardsCompatability(t *testing.T) {
 	expected2 := CommaSeparatedList{"test2.com", "example.org", "another2.net"}
 	assert.Equal(expected2, c.Domains, "should read legacy comma separated list domains")
 
-	expected3 := CommaSeparatedList{"test3.com", "example.org", "another3.net"}
+	expected3 := CommaSeparatedMap{"test3.com": "test3.com", "example.org": "example.org", "another3.net": "another3.net", "test4@example.org": "testuser4"}
 	assert.Equal(expected3, c.Whitelist, "should read legacy comma separated list whitelist")
 
 	// Name changed
@@ -219,7 +219,7 @@ func TestConfigParseEnvironmentBackwardsCompatability(t *testing.T) {
 		"COOKIE_DOMAINS": "test1.com,example.org",
 		"COOKIE_DOMAIN":  "another1.net",
 		"DOMAIN":         "test2.com,example.org",
-		"WHITELIST":      "test3.com,example.org",
+		"WHITELIST":      "test3.com,example.org,test4@example.org:testuser4",
 	}
 	for k, v := range vars {
 		os.Setenv(k, v)
@@ -238,7 +238,7 @@ func TestConfigParseEnvironmentBackwardsCompatability(t *testing.T) {
 	expected2 := CommaSeparatedList{"test2.com", "example.org"}
 	assert.Equal(expected2, c.Domains, "should read legacy comma separated list domains")
 
-	expected3 := CommaSeparatedList{"test3.com", "example.org"}
+	expected3 := CommaSeparatedMap{"test3.com": "test3.com", "example.org": "example.org", "test4@example.org": "testuser4"}
 	assert.Equal(expected3, c.Whitelist, "should read legacy comma separated list whitelist")
 
 	// Name changed

--- a/internal/server.go
+++ b/internal/server.go
@@ -94,7 +94,7 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 		}
 
 		// Validate user
-		valid := ValidateEmail(email)
+		valid, username := ValidateEmail(email)
 		if !valid {
 			logger.WithFields(logrus.Fields{
 				"email": email,
@@ -105,7 +105,8 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 
 		// Valid request
 		logger.Debugf("Allowing valid request ")
-		w.Header().Set("X-Forwarded-User", email)
+		w.Header().Set("X-Forwarded-User", username)
+		w.Header().Set("X-Forwarded-Email", email)
 		w.WriteHeader(200)
 	}
 }

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -115,6 +115,10 @@ func TestServerAuthHandlerValid(t *testing.T) {
 	users := res.Header["X-Forwarded-User"]
 	assert.Len(users, 1, "valid request should have X-Forwarded-User header")
 	assert.Equal([]string{"test@example.com"}, users, "X-Forwarded-User header should match user")
+
+	// Should pass through email
+	emails := res.Header["X-Forwarded-Email"]
+	assert.Equal(users, emails, "X-Forwarded-Email header should match user")
 }
 
 func TestServerAuthCallback(t *testing.T) {


### PR DESCRIPTION
[Gitea](http://gitea.io/) is a service that can use a reverse proxy header for authentication, but doesn't allow at-signs in usernames. The reverse proxy support is part of SSO support, and is tailored to having a single domain for everyone, and the reverse proxy doing the username mapping. For enterprise domains, we could implement stripping or mangling of the domain, but in private installations where friends gather, this isn't compatible with the federating principle of OAuth2.

I'm using it for personal personal repositories, but want to allow others to be able to access it. For small sites, I think having the ability to just do a simple mapping is easier than changing each of the protected services.

I believe this is conceptually compatible with #63, with trivial merging.