### PR TITLE
Fix Samesite change in Chrome/ium 80+

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 example
 .travis.yml
+.git

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -131,6 +131,10 @@ func MakeCookie(r *http.Request, email string) *http.Cookie {
 	expires := cookieExpiry()
 	mac := cookieSignature(r, email, fmt.Sprintf("%d", expires.Unix()))
 	value := fmt.Sprintf("%s|%d|%s", mac, expires.Unix(), email)
+	samesite := http.SameSiteLaxMode
+	if !config.InsecureCookie {
+		samesite = http.SameSiteNoneMode
+	}
 
 	return &http.Cookie{
 		Name:     config.CookieName,
@@ -139,6 +143,7 @@ func MakeCookie(r *http.Request, email string) *http.Cookie {
 		Domain:   cookieDomain(r),
 		HttpOnly: true,
 		Secure:   !config.InsecureCookie,
+		SameSite: samesite,
 		Expires:  expires,
 	}
 }


### PR DESCRIPTION
This makes the required changes to let traefik-forward-auth work in Chrom/ium 80+.
See https://www.chromestatus.com/feature/5633521622188032 and https://www.chromestatus.com/feature/5088147346030592 for context.

This could break existing setups but Chrome/ium would break those also.