### PR TITLE
Add .git to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 example
 .travis.yml
+.git


### PR DESCRIPTION
Because the Docker Image uses ``ADD . ...`` Docker adds the .git directory to the image which busts the layer cache when switching branches, adding remotes, etc. which is not always necessary as the code might not have changed.