### PR TITLE
Forward Header with oidc token  

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ traefik.toml:
 
     [entryPoints.http.auth.forward]
     address = "http://traefik-forward-auth:4181"
-    authResponseHeaders = ["X-Forwarded-User"]
+    authResponseHeaders = ["X-Forwarded-User", "X-Oidc-Token"]
 
 [docker]
 endpoint = "unix:///var/run/docker.sock"
@@ -319,6 +319,9 @@ Note, if you pass `whitelist` then only this is checked and `domain` is effectiv
 ### Forwarded Headers
 
 The authenticated user is set in the `X-Forwarded-User` header, to pass this on add this to the `authResponseHeaders` config option in traefik, as shown [here](https://github.com/thomseddon/traefik-forward-auth/blob/master/examples/docker-compose-dev.yml).
+
+The OIDC/JWT token is set in the `X-Oidc-Token` header, to pass this on add this to the `authResponseHeaders` config option in traefik; the value is encrypt,
+and need to be decrypted.
 
 ### Operation Modes
 

--- a/examples/traefik.toml
+++ b/examples/traefik.toml
@@ -38,7 +38,7 @@
 
     [entryPoints.http.auth.forward]
     address = "http://traefik-forward-auth:4181"
-    authResponseHeaders = ["X-Forwarded-User"]
+    authResponseHeaders = ["X-Forwarded-User", "X-Oidc-Token"]
 
 ################################################################
 # Traefik logs configuration

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -18,41 +18,41 @@ import (
 // Request Validation
 
 // Cookie = hash(secret, cookie domain, email, expires)|expires|email
-func ValidateCookie(r *http.Request, c *http.Cookie) (string, error) {
+func ValidateCookie(r *http.Request, c *http.Cookie) (string, string, error ) {
 	parts := strings.Split(c.Value, "|")
 
-	if len(parts) != 3 {
-		return "", errors.New("Invalid cookie format")
+	if len(parts) != 4 {
+		return "", "", errors.New("Invalid cookie format")
 	}
 
 	mac, err := base64.URLEncoding.DecodeString(parts[0])
 	if err != nil {
-		return "", errors.New("Unable to decode cookie mac")
+		return "", "", errors.New("Unable to decode cookie mac")
 	}
 
 	expectedSignature := cookieSignature(r, parts[2], parts[1])
 	expected, err := base64.URLEncoding.DecodeString(expectedSignature)
 	if err != nil {
-		return "", errors.New("Unable to generate mac")
+		return "", "", errors.New("Unable to generate mac")
 	}
 
 	// Valid token?
 	if !hmac.Equal(mac, expected) {
-		return "", errors.New("Invalid cookie mac")
+		return "", "", errors.New("Invalid cookie mac")
 	}
 
 	expires, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return "", errors.New("Unable to parse cookie expiry")
+		return "", "", errors.New("Unable to parse cookie expiry")
 	}
 
 	// Has it expired?
 	if time.Unix(expires, 0).Before(time.Now()) {
-		return "", errors.New("Cookie has expired")
+		return "", "", errors.New("Cookie has expired")
 	}
 
 	// Looks valid
-	return parts[2], nil
+	return parts[2], parts[3], nil 
 }
 
 // Validate email
@@ -127,10 +127,10 @@ func useAuthDomain(r *http.Request) (bool, string) {
 // Cookie methods
 
 // Create an auth cookie
-func MakeCookie(r *http.Request, email string) *http.Cookie {
+func MakeCookie(r *http.Request, email string, token string) *http.Cookie {
 	expires := cookieExpiry()
 	mac := cookieSignature(r, email, fmt.Sprintf("%d", expires.Unix()))
-	value := fmt.Sprintf("%s|%d|%s", mac, expires.Unix(), email)
+	value := fmt.Sprintf("%s|%d|%s|%s", mac, expires.Unix(), email, token)
 
 	return &http.Cookie{
 		Name:     config.CookieName,
@@ -142,6 +142,7 @@ func MakeCookie(r *http.Request, email string) *http.Cookie {
 		Expires:  expires,
 	}
 }
+
 
 // Make a CSRF cookie (used during login only)
 func MakeCSRFCookie(r *http.Request, nonce string) *http.Cookie {

--- a/internal/server.go
+++ b/internal/server.go
@@ -81,7 +81,7 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 		}
 
 		// Validate cookie
-		email, err := ValidateCookie(r, c)
+		email, oidc_token, err := ValidateCookie(r, c)
 		if err != nil {
 			if err.Error() == "Cookie has expired" {
 				logger.Info("Cookie has expired")
@@ -105,7 +105,8 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 
 		// Valid request
 		logger.Debugf("Allowing valid request ")
-		w.Header().Set("X-Forwarded-User", email)
+		w.Header().Add("X-Forwarded-User", email)
+		w.Header().Add("X-Oidc-Token", oidc_token)
 		w.WriteHeader(200)
 	}
 }
@@ -159,7 +160,7 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		}
 
 		// Generate cookie
-		http.SetCookie(w, MakeCookie(r, user.Email))
+		http.SetCookie(w, MakeCookie(r, user.Email, token))
 		logger.WithFields(logrus.Fields{
 			"user": user.Email,
 		}).Infof("Generated auth cookie")


### PR DESCRIPTION
## Scenario

For whom that want to use the user claims in their application or other layers (OPA I'm looking to your :D), this PR add the header `X-Oidc-Token` to the forwarded headers supported by ` thomseddon /
traefik-forward-auth`; with that, subsequent middlewares or application can decrypt and use the information inside the token.

Inspired by https://github.com/istio/istio/issues/11108

## What has been done

- [x] Added `oidc token` to AuthCookie.
- [x] Added `X-Oidc-Token` header.
- [x] Updated Docs to reflect the new header.
- [x] Manual Tests with Auth0/OIDC.
