### PR TITLE
Add automatic image support for various archs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,21 @@ RUN apk add --no-cache git
 
 # Copy & build
 ADD . /go/src/github.com/thomseddon/traefik-forward-auth/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -installsuffix nocgo -o /traefik-forward-auth github.com/thomseddon/traefik-forward-auth/cmd
+RUN set -ex; \
+	\
+ 	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+        armv[567])  Arch="arm"      ;; \
+        aarch64)    Arch='arm64'    ;; \
+        armhf)      Arch='arm'      ;; \
+		ppc64le)    Arch='ppc64le'  ;; \
+		s390x)      Arch='s390x'    ;; \
+		x86)        Arch='386'      ;; \
+		x86_64)     Arch='amd64'    ;; \
+ 		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
+ 	esac; \
+    \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${Arch} GO111MODULE=on go build -a -installsuffix nocgo -o /traefik-forward-auth github.com/thomseddon/traefik-forward-auth/cmd
 
 # Copy into scratch container
 FROM scratch

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -9,7 +9,21 @@ RUN apk add --no-cache git
 
 # Copy & build
 ADD . /go/src/github.com/thomseddon/traefik-forward-auth/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm GO111MODULE=on go build -a -installsuffix nocgo -o /traefik-forward-auth github.com/thomseddon/traefik-forward-auth/cmd
+RUN set -ex; \
+	\
+ 	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+        armv[567])  Arch="arm"      ;; \
+        aarch64)    Arch='arm64'    ;; \
+        armhf)      Arch='arm'      ;; \
+		ppc64le)    Arch='ppc64le'  ;; \
+		s390x)      Arch='s390x'    ;; \
+		x86)        Arch='386'      ;; \
+		x86_64)     Arch='amd64'    ;; \
+ 		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
+ 	esac; \
+    \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${Arch} GO111MODULE=on go build -a -installsuffix nocgo -o /traefik-forward-auth github.com/thomseddon/traefik-forward-auth/cmd
 
 # Copy into scratch container
 FROM scratch

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,7 +9,21 @@ RUN apk add --no-cache git
 
 # Copy & build
 ADD . /go/src/github.com/thomseddon/traefik-forward-auth/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GO111MODULE=on go build -a -installsuffix nocgo -o /traefik-forward-auth github.com/thomseddon/traefik-forward-auth/cmd
+RUN set -ex; \
+	\
+ 	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+        armv[567])  Arch="arm"      ;; \
+        aarch64)    Arch='arm64'    ;; \
+        armhf)      Arch='arm'      ;; \
+		ppc64le)    Arch='ppc64le'  ;; \
+		s390x)      Arch='s390x'    ;; \
+		x86)        Arch='386'      ;; \
+		x86_64)     Arch='amd64'    ;; \
+ 		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
+ 	esac; \
+    \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${Arch} GO111MODULE=on go build -a -installsuffix nocgo -o /traefik-forward-auth github.com/thomseddon/traefik-forward-auth/cmd
 
 # Copy into scratch container
 FROM scratch


### PR DESCRIPTION
The modification allows for automatic image support for various archs.


Added manifest file for the docker image for multi-arch support. 

I have added the build to this repo which support multi-arch:
https://hub.docker.com/repository/docker/imansour/traefik-forward-auth/

Supported arch:
linux/amd64, linux/386, linux/arm64, linux/ppc64le, linux/s390x, linux/arm/v7, linux/arm/v6
