### PR TITLE
Feature/whitelist domain in rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ You can restrict who can login with the following parameters:
 
 Note, if you pass both `whitelist` and `domain`, then the default behaviour is for only `whitelist` to be used and `domain` will be effectively ignored. You can allow users matching *either* `whitelist` or `domain` by passing the `match-whitelist-or-domain` parameter (this will be the default behaviour in v3).
 
+Domains and whitelists that are set in rules will obey the `match-whitelist-or-domain` parameter
+
 ### Forwarded Headers
 
 The authenticated user is set in the `X-Forwarded-User` header, to pass this on add this to the `authResponseHeaders` config option in traefik, as shown below in the [Applying Authentication](#applying-authentication) section.

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -95,6 +95,32 @@ func ValidateEmail(email string) bool {
 	return false
 }
 
+//ValidateWhitelist is true if it is explicitly listed,
+//or if it matches a whitelisted domain and Config.MatchWhitelistOrDomain is true
+func ValidateWhitelist(entry string, whitelistItems []string) bool {
+	if len(whitelistItems) == 0 {
+		return false
+	}
+	for _, whitelisted := range whitelistItems {
+		if entry == whitelisted {
+			return true
+		}
+		if config.MatchWhitelistOrDomain {
+			parts := strings.Split(entry, "@")
+			if len(parts) == 1 {
+			//a string that was not already a matched domain or an address
+			return false
+			}
+			domain := parts[1]
+			if domain == whitelisted {
+				return true
+			}
+
+		}
+	}
+	return false
+}
+
 // Utility methods
 
 // Get the redirect base

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -59,39 +59,57 @@ func ValidateCookie(r *http.Request, c *http.Cookie) (string, error) {
 // ValidateEmail checks if the given email address matches either a whitelisted
 // email address, as defined by the "whitelist" config parameter. Or is part of
 // a permitted domain, as defined by the "domains" config parameter
+// if an email or domain is added by a rule, it is merged with the config before being evaluated
+// in order to respect the match whitelist or domain parameter
 func ValidateEmail(email string) bool {
+
 	// Do we have any validation to perform?
-	if len(config.Whitelist) == 0 && len(config.Domains) == 0 {
+	if len(config.Whitelist) == 0 && len(config.Domains) == 0 && len(config.Rules) == 0 {
 		return true
 	}
+	var whitelists []string
+	var domains []string
+
+	// rule validation
+	for _, rule := range config.Rules {
+		for _, whitelisted := range rule.Whitelist {
+			whitelists = append(whitelists, whitelisted)
+		}
+		for _, domain := range rule.Domains {
+			domains = append(domains, domain)
+		}
+	}
+	domains = append(domains, config.Domains...)
+	whitelists = append(whitelists, config.Whitelist...)
 
 	// Email whitelist validation
-	if len(config.Whitelist) > 0 {
-		for _, whitelist := range config.Whitelist {
-			if email == whitelist {
-				return true
-			}
+	for _, whitelist := range whitelists {
+		if email == whitelist {
+			return true
 		}
+	}
 
-		// If we're not matching *either*, stop here
-		if !config.MatchWhitelistOrDomain {
-			return false
-		}
+	// If there's a whitelist and we're not matching *either*, stop here
+	if len(whitelists) > 0 && !config.MatchWhitelistOrDomain {
+		return false
 	}
 
 	// Domain validation
-	if len(config.Domains) > 0 {
-		parts := strings.Split(email, "@")
-		if len(parts) < 2 {
-			return false
-		}
-		for _, domain := range config.Domains {
-			if domain == parts[1] {
-				return true
-			}
+	for _, domain := range domains {
+		if emailIsInDomain(email, domain) {
+			return true
 		}
 	}
-
+	return false
+}
+func emailIsInDomain(email string, domain string) bool {
+	parts := strings.Split(email, "@")
+	if len(parts) < 2 {
+		return false
+	}
+	if parts[1] == domain {
+		return true
+	}
 	return false
 }
 

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -72,9 +72,20 @@ func TestAuthValidateEmail(t *testing.T) {
 	v = ValidateEmail("one@two.com")
 	assert.True(v, "should allow any domain if email domain is not defined")
 
-	// Should allow email specified in a whitelist rule
+	// Should allow email specified in a rule whitelist
 	config.Rules = map[string]*Rule{
 		"whitelisted-from-rule": {
+			Rule:      "test-whitelist-rule",
+			Whitelist: []string{"whitelisted-from-rule@example.com"},
+		},
+	}
+
+	v = ValidateEmail("whitelisted-from-rule@example.com")
+	assert.True(v, "should allow email from whitelist rule")
+
+	// Should allow domain specified in a rule whitelist
+	config.Rules = map[string]*Rule{
+		"whitelisted-from-domain": {
 			Rule:      "test-whitelist-rule",
 			Whitelist: []string{"whitelisted-from-rule@example.com"},
 		},
@@ -111,29 +122,6 @@ func TestAuthValidateEmail(t *testing.T) {
 	v2 = ValidateEmail("allowed-from-whitelist-rule2@example.com")
 	assert.True((v1 == v2), "should allow emails from multiple whitelist rules")
 
-	// Should allow domain to be specified in a rule
-	config.Rules = map[string]*Rule{
-		"allowed-from-domain-rule": {
-			Rule:    "domain-rule1",
-			Domains: []string{"example.com"},
-		},
-	}
-
-	v = ValidateEmail("whitelisted-from-domain@example.com")
-	assert.True(v, "should allow email from domain rule")
-
-	// Should allow multiple domains to be specified in a rule
-	config.Rules = map[string]*Rule{
-		"allowed-from-domain-rule-1": {
-			Rule:    "domain-rule1",
-			Domains: []string{"example.com"},
-		},
-		"allowed-from-domain-rule2": {
-			Rule:    "domain-rule2",
-			Domains: []string{"example.org"},
-		},
-	}
-
 	v1 = ValidateEmail("allowed-from-domain-rule1@example.org")
 	v2 = ValidateEmail("allowed-from-domain-rule2@example.com")
 	assert.True((v1 == v2), "Should allow emails from multiple domain rules")
@@ -167,56 +155,80 @@ func TestAuthValidateEmail(t *testing.T) {
 	config.MatchWhitelistOrDomain = false
 
 	v = ValidateEmail("test@test.com")
-	assert.True(v, "should allow user from whitelist config if MatchWhitelistOrDomain is disabled")
+	assert.True(v, "should allow user from whitelist if MatchWhitelistOrDomain is disabled")
 
 	v = ValidateEmail("test@example.com")
-	assert.False(v, "should not allow user from domain config if a whitelist is specified and MatchWhitelistOrDomain is disabled")
+	assert.False(v, "should not allow user from domain if MatchWhitelistOrDomain is disabled")
 
-	// Should allow only matching email address when
-	// MatchWhitelistOrDomain is disabled
+	// Should allow matching domains in the whitelist of a rule
+
+	var goodAddress string = "good@good.example.com"
+	var goodAddress2 string = "good2@good.example.com"
+
+	var goodDomain string = "good.example.com"
+	var goodDomain2 string = "good2.example.com"
+
 	config.Rules = map[string]*Rule{
-		"allowed-from-whitelist-rule": {
-			Rule:      "whitelist-rule",
-			Whitelist: []string{"allowed-from-whitelist-rule@example.com"},
-		},
-		"allowed-from-domain-rule": {
-			Rule:    "domain-rule",
-			Domains: []string{"example.org"},
-		},
-	}
-	config.MatchWhitelistOrDomain = false
-
-	v = ValidateEmail("allowed-from-whitelist-rule@example.com")
-	assert.True(v, "should allow user from whitelist rule if MatchWhitelistOrDomain is disabled")
-
-	v = ValidateEmail("not-allowed-from-domain-rule@example.org")
-	assert.False(v, "should not allow user from domain rule if MatchWhitelistOrDomain is disabled")
-
-	v = ValidateEmail("one@two.com")
-	assert.False(v, "should not allow user not in whitelist or domain")
-
-	// Should allow matching email address or domain from a rule
-	// when MatchWhitelistOrDomain is enabled
-	config.Rules = map[string]*Rule{
-		"allowed-from-whitelist-rule": {
-			Rule:      "whitelist-rule",
-			Whitelist: []string{"allowed-from-whitelist-rule@example.com"},
-		},
-		"allowed-from-domain-rule": {
-			Rule:    "domain-rule",
-			Domains: []string{"example.org"},
+		"whitelist-contains-domain": {
+			Whitelist: []string{goodDomain},
 		},
 	}
 	config.MatchWhitelistOrDomain = true
 
-	v = ValidateEmail("allowed-from-whitelist-rule@example.com")
-	assert.True(v, "should allow user from whitelist rule if MatchWhitelistOrDomain is true")
+	v = ValidateEmail(goodAddress)
+	assert.True(v, "should allow user from domain in whitelist if MatchWhitelistOrDomain is enabled")
+	config.MatchWhitelistOrDomain = false
 
-	v = ValidateEmail("not-allowed-from-domain-rule@example.org")
-	assert.True(v, "should allow user from domain rule if MatchWhitelistOrDomain is enabled")
+	v = ValidateEmail(goodAddress)
+	assert.False(v, "should not allow user from domain in whitelist if MatchWhitelistOrDomain is disabled")
 
 	v = ValidateEmail("one@two.com")
-	assert.False(v, "should not allow user not in whitelist or domain rule")
+	assert.False(v, "should not allow user not in whitelist, domain, or rule")
+
+	// Should allow matching domains in multiple whitelist rules
+	config.Rules = map[string]*Rule{
+		"whitelist-contains-domain1": {
+			Whitelist: []string{goodDomain},
+		},
+		"whitelist-contains-domain2": {
+			Whitelist: []string{goodDomain2},
+		},
+	}
+	v1 = ValidateEmail(goodAddress)
+	v2 = ValidateEmail(goodAddress2)
+	assert.True((true == v1 == v2), "should allow domains from multiple whitelist rules")
+
+	// Should allow matching addresses in the whitelist of a rule
+	config.Rules = map[string]*Rule{
+		"whitelist-contains-address": {
+			Whitelist: []string{goodAddress},
+		},
+	}
+
+	config.MatchWhitelistOrDomain = false
+	v1 = ValidateEmail(goodAddress)
+
+	config.MatchWhitelistOrDomain = true
+	v2 = ValidateEmail(goodAddress)
+
+	assert.True(true == v1 == v2, "addresses in a whitelist should ignore the MatchWhitelistOrDomain")
+
+	// Should allow matching addresses in multiple whitelist rules
+	config.Rules = map[string]*Rule{
+		"whitelist-contains-address1": {
+			Whitelist: []string{goodAddress},
+		},
+		"whitelist-contains-address2": {
+			Whitelist: []string{goodAddress2},
+		},
+	}
+	v1 = ValidateEmail(goodAddress, )
+	v2 = ValidateEmail(goodAddress2)
+	assert.True((true == v1 == v2), "should allow addresses from multiple whitelist rules")
+
+	v = ValidateEmail("one@two.com")
+	assert.False(v, "should not allow user not in whitelist, domain, or rule")
+
 }
 func TestRedirectUri(t *testing.T) {
 	assert := assert.New(t)

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -126,13 +126,11 @@ func TestAuthValidateWhitelist(t *testing.T) {
 	var goodAddress2 string = "good2@good2.example.com"
 
 	var badAddress string = "bad@bad.example.com"
-	//var badAddress2 string = "bad2@bad2.example.com"
 
 	var goodDomain string = "good.example.com"
 	var goodDomain2 string = "good2.example.com"
 
 	var badDomain string = "bad.example.com"
-	//var badDomain2 string = "bad2.example.com"
 
 	ruleName := "whitelist-rule"
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -210,6 +210,12 @@ func (c *Config) parseUnknownFlag(option string, arg flags.SplitArgument, args [
 			rule.Rule = val
 		case "provider":
 			rule.Provider = val
+		case "whitelist":
+			list := CommaSeparatedList{}
+			rule.Whitelist = list
+		case "domains":
+			list := CommaSeparatedList{}
+			rule.Domains = list
 		default:
 			return args, fmt.Errorf("invalid route param: %v", option)
 		}
@@ -325,9 +331,11 @@ func (c *Config) setupProvider(name string) error {
 
 // Rule holds defined rules
 type Rule struct {
-	Action   string
-	Rule     string
-	Provider string
+	Action    string
+	Rule      string
+	Provider  string
+	Whitelist []string
+	Domains   []string
 }
 
 // NewRule creates a new rule object

--- a/internal/config.go
+++ b/internal/config.go
@@ -212,10 +212,8 @@ func (c *Config) parseUnknownFlag(option string, arg flags.SplitArgument, args [
 			rule.Provider = val
 		case "whitelist":
 			list := CommaSeparatedList{}
+			list.UnmarshalFlag(val)
 			rule.Whitelist = list
-		case "domains":
-			list := CommaSeparatedList{}
-			rule.Domains = list
 		default:
 			return args, fmt.Errorf("invalid route param: %v", option)
 		}
@@ -335,7 +333,6 @@ type Rule struct {
 	Rule      string
 	Provider  string
 	Whitelist []string
-	Domains   []string
 }
 
 // NewRule creates a new rule object
@@ -358,6 +355,27 @@ func (r *Rule) Validate(c *Config) error {
 	}
 
 	return c.setupProvider(r.Provider)
+}
+//EntryInWhitelist is true if it is explicitly listed, 
+//or if it matches a whitelisted domain and Config.MatchWhitelistOrDomain is true 
+func (r *Rule) EntryInWhitelist(entry string) bool {
+	if r == nil {
+		return false
+	}
+	for _, whitelisted := range r.Whitelist {
+		if entry == whitelisted {
+			return true
+		}
+		if config.MatchWhitelistOrDomain {
+			parts := strings.Split(entry, "@")
+			domain := parts[1]
+			if domain == whitelisted {
+				return true
+			}
+
+		}
+	}
+	return false
 }
 
 // Legacy support for comma separated lists

--- a/internal/config.go
+++ b/internal/config.go
@@ -356,27 +356,6 @@ func (r *Rule) Validate(c *Config) error {
 
 	return c.setupProvider(r.Provider)
 }
-//EntryInWhitelist is true if it is explicitly listed, 
-//or if it matches a whitelisted domain and Config.MatchWhitelistOrDomain is true 
-func (r *Rule) EntryInWhitelist(entry string) bool {
-	if r == nil {
-		return false
-	}
-	for _, whitelisted := range r.Whitelist {
-		if entry == whitelisted {
-			return true
-		}
-		if config.MatchWhitelistOrDomain {
-			parts := strings.Split(entry, "@")
-			domain := parts[1]
-			if domain == whitelisted {
-				return true
-			}
-
-		}
-	}
-	return false
-}
 
 // Legacy support for comma separated lists
 

--- a/internal/server.go
+++ b/internal/server.go
@@ -99,8 +99,11 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 			}
 			return
 		}
-		//Validate Whitelist
-		whitelisted := config.Rules[rule].EntryInWhitelist(email)
+		//Validate whitelist
+		var whitelisted bool
+		if config.Rules[rule] != nil {
+			whitelisted = ValidateWhitelist(email, config.Rules[rule].Whitelist)
+		}
 		if !whitelisted {
 			// Validate user
 			valid := ValidateEmail(email)

--- a/internal/server.go
+++ b/internal/server.go
@@ -99,15 +99,17 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 			}
 			return
 		}
-
-		// Validate user
-		valid := ValidateEmail(email)
-		if !valid {
-			logger.WithField("email", email).Warn("Invalid email")
-			http.Error(w, "Not authorized", 401)
-			return
+		//Validate Whitelist
+		whitelisted := config.Rules[rule].EntryInWhitelist(email)
+		if !whitelisted {
+			// Validate user
+			valid := ValidateEmail(email)
+			if !valid {
+				logger.WithField("email", email).Warn("Invalid email")
+				http.Error(w, "Not authorized", 401)
+				return
+			}
 		}
-
 		// Valid request
 		logger.Debug("Allowing valid request")
 		w.Header().Set("X-Forwarded-User", email)


### PR DESCRIPTION
Continuation of #63 

- rebase to master
- support the MatchWhitelistOrDomain parameter
- Combine the original whitelist and domain rule fields into one named ‘whitelist’
which accepts either an email address or domain