### PR TITLE
Remove unused user fields

### DIFF
--- a/internal/provider/google_test.go
+++ b/internal/provider/google_test.go
@@ -144,8 +144,5 @@ func TestGoogleGetUser(t *testing.T) {
 	user, err := p.GetUser("123456789")
 	assert.Nil(err)
 
-	assert.Equal("1", user.ID)
 	assert.Equal("example@example.com", user.Email)
-	assert.True(user.Verified)
-	assert.Equal("example.com", user.Hd)
 }

--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -91,18 +91,9 @@ func (o *OIDC) GetUser(token string) (User, error) {
 	}
 
 	// Extract custom claims
-	var claims struct {
-		ID       string `json:"sub"`
-		Email    string `json:"email"`
-		Verified bool   `json:"email_verified"`
-	}
-	if err := idToken.Claims(&claims); err != nil {
+	if err := idToken.Claims(&user); err != nil {
 		return user, err
 	}
-
-	user.ID = claims.ID
-	user.Email = claims.Email
-	user.Verified = claims.Verified
 
 	return user, nil
 }

--- a/internal/provider/oidc_test.go
+++ b/internal/provider/oidc_test.go
@@ -124,9 +124,7 @@ func TestOIDCGetUser(t *testing.T) {
 	// Get user
 	user, err := provider.GetUser(token)
 	assert.Nil(err)
-	assert.Equal("1", user.ID)
 	assert.Equal("example@example.com", user.Email)
-	assert.True(user.Verified)
 }
 
 // Utils

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -28,10 +28,7 @@ type token struct {
 
 // User is the authenticated user
 type User struct {
-	ID       string `json:"id"`
-	Email    string `json:"email"`
-	Verified bool   `json:"verified_email"`
-	Hd       string `json:"hd"`
+	Email string `json:"email"`
 }
 
 // OAuthProvider is a provider using the oauth2 library


### PR DESCRIPTION
These aren't actually used anywhere and can result in a parse error if the ID field isn't a string

This also helps with the user of different providers either via `oidc` or `generic-oauth` (currently in #93)