### PR TITLE
Fail if there is an error retrieving the user + extra tests

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -167,6 +167,7 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		user, err := p.GetUser(token)
 		if err != nil {
 			logger.WithField("error", err).Error("Error getting user")
+			http.Error(w, "Service unavailable", 503)
 			return
 		}
 


### PR DESCRIPTION
Previously this would fail, but permit the request, which isn't normally what you'd want.