### PR TITLE
Allow custom key to be used for whitelist and X-Forwarded-User instead of the hardcoded email

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,39 @@
+name: Traefik Forward Auth
+on: [push]
+jobs:
+  test:
+    name: Test with Go version -
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go: ['1.12', '1.13', '1.14']
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Run Tests
+        run: go test ./...
+
+  publish:
+    name: Publish Docker image
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: '0'
+      - name: Publish to Docker Registry
+        uses: docker/build-push-action@v1
+        with:
+          repository: ${{ github.repository }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tag_with_ref: true
+          tag_with_sha: true
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,28 +1,28 @@
 name: Traefik Forward Auth
 on: [push]
 jobs:
-#  test:
-  #    name: Test with Go version -
-  #    runs-on: ubuntu-latest
-  #
-  #    strategy:
-  #      matrix:
-  #        go: ['1.12', '1.13', '1.14']
-  #
-  #    steps:
-  #      - uses: actions/checkout@v1
-  #
-  #      - name: Setup Go
-  #        uses: actions/setup-go@v1
-  #        with:
-  #          go-version: ${{ matrix.go }}
-  #
-  #      - name: Run Tests
-  #        run: go test ./...
+  test:
+    name: Test with Go version -
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go: ['1.12', '1.13', '1.14']
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Run Tests
+        run: go test ./...
 
   publish:
     name: Publish Docker image
-    #    needs: test
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,28 +1,28 @@
 name: Traefik Forward Auth
 on: [push]
 jobs:
-  test:
-    name: Test with Go version -
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        go: ['1.12', '1.13', '1.14']
-
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Setup Go
-        uses: actions/setup-go@v1
-        with:
-          go-version: ${{ matrix.go }}
-
-      - name: Run Tests
-        run: go test ./...
+#  test:
+  #    name: Test with Go version -
+  #    runs-on: ubuntu-latest
+  #
+  #    strategy:
+  #      matrix:
+  #        go: ['1.12', '1.13', '1.14']
+  #
+  #    steps:
+  #      - uses: actions/checkout@v1
+  #
+  #      - name: Setup Go
+  #        uses: actions/setup-go@v1
+  #        with:
+  #          go-version: ${{ matrix.go }}
+  #
+  #      - name: Run Tests
+  #        run: go test ./...
 
   publish:
     name: Publish Docker image
-    needs: test
+    #    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 # Setup
 RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 # Setup
 RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 # Setup
 RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth

--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ Application Options:
   --csrf-cookie-name=                                   CSRF Cookie Name (default: _forward_auth_csrf) [$CSRF_COOKIE_NAME]
   --default-action=[auth|allow]                         Default action (default: auth) [$DEFAULT_ACTION]
   --default-provider=[google|oidc|generic-oauth]        Default provider (default: google) [$DEFAULT_PROVIDER]
-  --domain=                                             Only allow given email domains, can be set multiple times [$DOMAIN]
+  --domain=                                             Only allow given email domains, comma delimited, can be set multiple times [$DOMAIN]
   --lifetime=                                           Lifetime in seconds (default: 43200) [$LIFETIME]
   --logout-redirect=                                    URL to redirect to following logout [$LOGOUT_REDIRECT]
   --url-path=                                           Callback URL Path (default: /_oauth) [$URL_PATH]
   --secret=                                             Secret used for signing (required) [$SECRET]
-  --whitelist=                                          Only allow given email addresses, can be set multiple times [$WHITELIST]
+  --whitelist=                                          Only allow given email addresses, comma delimited, can be set multiple times [$WHITELIST]
   --rule.<name>.<param>=                                Rule definitions, param can be: "action", "rule" or "provider"
 
 Google Provider:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/thomseddon/traefik-forward-auth
 go 1.13
 
 require (
+	github.com/Jeffail/gabs/v2 v2.5.1
 	github.com/containous/traefik/v2 v2.1.2
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomseddon/traefik-forward-auth
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Jeffail/gabs/v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/ExpediaDotCom/haystack-client-go v0.0.0-20190315171017-e7edbdf53a61/go.mod h1:62qWSDaEI0BLykU+zQza5CAKgW0lOy9oBSz3/DvYz4w=
+github.com/Jeffail/gabs/v2 v2.5.1 h1:ANfZYjpMlfTTKebycu4X1AgkVWumFVDYQl7JwOr4mDk=
+github.com/Jeffail/gabs/v2 v2.5.1/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.20.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -18,7 +18,7 @@ import (
 // Request Validation
 
 // ValidateCookie verifies that a cookie matches the expected format of:
-// Cookie = hash(secret, cookie domain, email, expires)|expires|email
+// Cookie = hash(secret, cookie domain, user, expires)|expires|user
 func ValidateCookie(r *http.Request, c *http.Cookie) (string, error) {
 	parts := strings.Split(c.Value, "|")
 
@@ -56,10 +56,10 @@ func ValidateCookie(r *http.Request, c *http.Cookie) (string, error) {
 	return parts[2], nil
 }
 
-// ValidateEmail checks if the given email address matches either a whitelisted
-// email address, as defined by the "whitelist" config parameter. Or is part of
+// ValidateUser checks if the given user matches either a whitelisted
+// user, as defined by the "whitelist" config parameter. Or is part of
 // a permitted domain, as defined by the "domains" config parameter
-func ValidateEmail(email string) bool {
+func ValidateUser(user string) bool {
 	// Do we have any validation to perform?
 	if len(config.Whitelist) == 0 && len(config.Domains) == 0 {
 		return true
@@ -68,7 +68,7 @@ func ValidateEmail(email string) bool {
 	// Email whitelist validation
 	if len(config.Whitelist) > 0 {
 		for _, whitelist := range config.Whitelist {
-			if email == whitelist {
+			if user == whitelist {
 				return true
 			}
 		}
@@ -81,7 +81,7 @@ func ValidateEmail(email string) bool {
 
 	// Domain validation
 	if len(config.Domains) > 0 {
-		parts := strings.Split(email, "@")
+		parts := strings.Split(user, "@")
 		if len(parts) < 2 {
 			return false
 		}
@@ -141,10 +141,10 @@ func useAuthDomain(r *http.Request) (bool, string) {
 // Cookie methods
 
 // MakeCookie creates an auth cookie
-func MakeCookie(r *http.Request, email string) *http.Cookie {
+func MakeCookie(r *http.Request, user string) *http.Cookie {
 	expires := cookieExpiry()
-	mac := cookieSignature(r, email, fmt.Sprintf("%d", expires.Unix()))
-	value := fmt.Sprintf("%s|%d|%s", mac, expires.Unix(), email)
+	mac := cookieSignature(r, user, fmt.Sprintf("%d", expires.Unix()))
+	value := fmt.Sprintf("%s|%d|%s", mac, expires.Unix(), user)
 
 	return &http.Cookie{
 		Name:     config.CookieName,

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -67,31 +67,31 @@ func TestAuthValidateEmail(t *testing.T) {
 	config, _ = NewConfig([]string{})
 
 	// Should allow any
-	v := ValidateEmail("test@test.com")
+	v := ValidateUser("test@test.com")
 	assert.True(v, "should allow any domain if email domain is not defined")
-	v = ValidateEmail("one@two.com")
+	v = ValidateUser("one@two.com")
 	assert.True(v, "should allow any domain if email domain is not defined")
 
 	// Should block non matching domain
 	config.Domains = []string{"test.com"}
-	v = ValidateEmail("one@two.com")
+	v = ValidateUser("one@two.com")
 	assert.False(v, "should not allow user from another domain")
 
 	// Should allow matching domain
 	config.Domains = []string{"test.com"}
-	v = ValidateEmail("test@test.com")
+	v = ValidateUser("test@test.com")
 	assert.True(v, "should allow user from allowed domain")
 
 	// Should block non whitelisted email address
 	config.Domains = []string{}
 	config.Whitelist = []string{"test@test.com"}
-	v = ValidateEmail("one@two.com")
+	v = ValidateUser("one@two.com")
 	assert.False(v, "should not allow user not in whitelist")
 
 	// Should allow matching whitelisted email address
 	config.Domains = []string{}
 	config.Whitelist = []string{"test@test.com"}
-	v = ValidateEmail("test@test.com")
+	v = ValidateUser("test@test.com")
 	assert.True(v, "should allow user in whitelist")
 
 	// Should allow only matching email address when
@@ -99,11 +99,11 @@ func TestAuthValidateEmail(t *testing.T) {
 	config.Domains = []string{"example.com"}
 	config.Whitelist = []string{"test@test.com"}
 	config.MatchWhitelistOrDomain = false
-	v = ValidateEmail("test@test.com")
+	v = ValidateUser("test@test.com")
 	assert.True(v, "should allow user in whitelist")
-	v = ValidateEmail("test@example.com")
+	v = ValidateUser("test@example.com")
 	assert.False(v, "should not allow user from valid domain")
-	v = ValidateEmail("one@two.com")
+	v = ValidateUser("one@two.com")
 	assert.False(v, "should not allow user not in either")
 
 	// Should allow either matching domain or email address when
@@ -111,12 +111,17 @@ func TestAuthValidateEmail(t *testing.T) {
 	config.Domains = []string{"example.com"}
 	config.Whitelist = []string{"test@test.com"}
 	config.MatchWhitelistOrDomain = true
-	v = ValidateEmail("test@test.com")
+	v = ValidateUser("test@test.com")
 	assert.True(v, "should allow user in whitelist")
-	v = ValidateEmail("test@example.com")
+	v = ValidateUser("test@example.com")
 	assert.True(v, "should allow user from valid domain")
-	v = ValidateEmail("one@two.com")
+	v = ValidateUser("one@two.com")
 	assert.False(v, "should not allow user not in either")
+
+	// Should allow comma separated email
+	config.Whitelist = []string{"test@test.com", "test2@test2.com"}
+	v = ValidateUser("test2@test2.com")
+	assert.True(v, "should allow user in whitelist")
 }
 
 func TestRedirectUri(t *testing.T) {

--- a/internal/config.go
+++ b/internal/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	MatchWhitelistOrDomain bool                 `long:"match-whitelist-or-domain" env:"MATCH_WHITELIST_OR_DOMAIN" description:"Allow users that match *either* whitelist or domain (enabled by default in v3)"`
 	Path                   string               `long:"url-path" env:"URL_PATH" default:"/_oauth" description:"Callback URL Path"`
 	SecretString           string               `long:"secret" env:"SECRET" description:"Secret used for signing (required)" json:"-"`
-	UserIDKey              string               `long:"user-id-key" env:"USER_ID_KEY" default:"email" description:"Key used to grab the UserID for use in whitelist and X-Forwarded-User"`
+	UserIDPath             string               `long:"user-id-path" env:"USER_ID_PATH" default:"email" description:"Dot notation path of a UserID for use with whitelist and X-Forwarded-User"`
 	Whitelist              CommaSeparatedList   `long:"whitelist" env:"WHITELIST" env-delim:"," description:"Only allow given email addresses, comma delimited, can be set multiple times"`
 
 	Providers provider.Providers `group:"providers" namespace:"providers" env-namespace:"PROVIDERS"`
@@ -318,9 +318,7 @@ func (c *Config) setupProvider(name string) error {
 	}
 
 	// Setup
-	err = p.Setup()
-
-	if err != nil {
+	if err := p.Setup(); err != nil {
 		return err
 	}
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -32,13 +32,14 @@ type Config struct {
 	CSRFCookieName         string               `long:"csrf-cookie-name" env:"CSRF_COOKIE_NAME" default:"_forward_auth_csrf" description:"CSRF Cookie Name"`
 	DefaultAction          string               `long:"default-action" env:"DEFAULT_ACTION" default:"auth" choice:"auth" choice:"allow" description:"Default action"`
 	DefaultProvider        string               `long:"default-provider" env:"DEFAULT_PROVIDER" default:"google" choice:"google" choice:"oidc" choice:"generic-oauth" description:"Default provider"`
-	Domains                CommaSeparatedList   `long:"domain" env:"DOMAIN" env-delim:"," description:"Only allow given email domains, can be set multiple times"`
+	Domains                CommaSeparatedList   `long:"domain" env:"DOMAIN" env-delim:"," description:"Only allow given email domains, comma delimited, can be set multiple times"`
 	LifetimeString         int                  `long:"lifetime" env:"LIFETIME" default:"43200" description:"Lifetime in seconds"`
 	LogoutRedirect         string               `long:"logout-redirect" env:"LOGOUT_REDIRECT" description:"URL to redirect to following logout"`
 	MatchWhitelistOrDomain bool                 `long:"match-whitelist-or-domain" env:"MATCH_WHITELIST_OR_DOMAIN" description:"Allow users that match *either* whitelist or domain (enabled by default in v3)"`
 	Path                   string               `long:"url-path" env:"URL_PATH" default:"/_oauth" description:"Callback URL Path"`
 	SecretString           string               `long:"secret" env:"SECRET" description:"Secret used for signing (required)" json:"-"`
-	Whitelist              CommaSeparatedList   `long:"whitelist" env:"WHITELIST" env-delim:"," description:"Only allow given email addresses, can be set multiple times"`
+	UserIDKey              string               `long:"user-id-key" env:"USER_ID_KEY" default:"email" description:"Key used to grab the UserID for use in whitelist and X-Forwarded-User"`
+	Whitelist              CommaSeparatedList   `long:"whitelist" env:"WHITELIST" env-delim:"," description:"Only allow given email addresses, comma delimited, can be set multiple times"`
 
 	Providers provider.Providers `group:"providers" namespace:"providers" env-namespace:"PROVIDERS"`
 	Rules     map[string]*Rule   `long:"rule.<name>.<param>" description:"Rule definitions, param can be: \"action\", \"rule\" or \"provider\""`
@@ -318,6 +319,7 @@ func (c *Config) setupProvider(name string) error {
 
 	// Setup
 	err = p.Setup()
+
 	if err != nil {
 		return err
 	}

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -105,6 +105,17 @@ func TestConfigParseRuleError(t *testing.T) {
 	assert.Equal(map[string]*Rule{}, c.Rules)
 }
 
+func TestConfigCommaSeperated(t *testing.T) {
+	assert := assert.New(t)
+	c, err := NewConfig([]string{
+		"--whitelist=test@test.com,test2@test2.com",
+	})
+	require.Nil(t, err)
+
+	expected1 := CommaSeparatedList{"test@test.com", "test2@test2.com"}
+	assert.Equal(expected1, c.Whitelist, "should read legacy comma separated list whitelist")
+}
+
 func TestConfigFlagBackwardsCompatability(t *testing.T) {
 	assert := assert.New(t)
 	c, err := NewConfig([]string{

--- a/internal/provider/generic_oauth.go
+++ b/internal/provider/generic_oauth.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -66,13 +65,11 @@ func (o *GenericOAuth) ExchangeCode(redirectURI, code string) (string, error) {
 	return token.AccessToken, nil
 }
 
-// GetUser uses the given token and returns a complete provider.User object
-func (o *GenericOAuth) GetUser(token string) (User, error) {
-	var user User
-
+// GetUser uses the given token and returns a UserID
+func (o *GenericOAuth) GetUser(token, userIDKey string) (UserID, error) {
 	req, err := http.NewRequest("GET", o.UserURL, nil)
 	if err != nil {
-		return user, err
+		return "", err
 	}
 
 	if o.TokenStyle == "header" {
@@ -86,11 +83,9 @@ func (o *GenericOAuth) GetUser(token string) (User, error) {
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
-		return user, err
+		return "", err
 	}
-
 	defer res.Body.Close()
-	err = json.NewDecoder(res.Body).Decode(&user)
 
-	return user, err
+	return GetUserID(res.Body, userIDKey)
 }

--- a/internal/provider/generic_oauth.go
+++ b/internal/provider/generic_oauth.go
@@ -66,7 +66,7 @@ func (o *GenericOAuth) ExchangeCode(redirectURI, code string) (string, error) {
 }
 
 // GetUser uses the given token and returns a UserID
-func (o *GenericOAuth) GetUser(token, userIDKey string) (UserID, error) {
+func (o *GenericOAuth) GetUser(token, userIDPath string) (UserID, error) {
 	req, err := http.NewRequest("GET", o.UserURL, nil)
 	if err != nil {
 		return "", err
@@ -87,5 +87,5 @@ func (o *GenericOAuth) GetUser(token, userIDKey string) (UserID, error) {
 	}
 	defer res.Body.Close()
 
-	return GetUserID(res.Body, userIDKey)
+	return GetUserID(res.Body, userIDPath)
 }

--- a/internal/provider/generic_oauth_test.go
+++ b/internal/provider/generic_oauth_test.go
@@ -133,8 +133,8 @@ func TestGenericOAuthGetUser(t *testing.T) {
 	// AuthStyleInHeader is attempted
 	p.Config.Endpoint.AuthStyle = oauth2.AuthStyleInParams
 
-	user, err := p.GetUser("123456789")
+	user, err := p.GetUser("123456789", "email")
 	assert.Nil(err)
 
-	assert.Equal("example@example.com", user.Email)
+	assert.Equal("example@example.com", user)
 }

--- a/internal/provider/google.go
+++ b/internal/provider/google.go
@@ -92,8 +92,8 @@ func (g *Google) ExchangeCode(redirectURI, code string) (string, error) {
 	return token.Token, err
 }
 
-// GetUser uses the given token and returns a userID
-func (g *Google) GetUser(token, userIDKey string) (UserID, error) {
+// GetUser uses the given token and returns a userID located at the json path
+func (g *Google) GetUser(token, userIDPath string) (UserID, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", g.UserURL.String(), nil)
 	if err != nil {
@@ -107,5 +107,5 @@ func (g *Google) GetUser(token, userIDKey string) (UserID, error) {
 	}
 
 	defer res.Body.Close()
-	return GetUserID(res.Body, userIDKey)
+	return GetUserID(res.Body, userIDPath)
 }

--- a/internal/provider/google.go
+++ b/internal/provider/google.go
@@ -92,24 +92,20 @@ func (g *Google) ExchangeCode(redirectURI, code string) (string, error) {
 	return token.Token, err
 }
 
-// GetUser uses the given token and returns a complete provider.User object
-func (g *Google) GetUser(token string) (User, error) {
-	var user User
-
+// GetUser uses the given token and returns a userID
+func (g *Google) GetUser(token, userIDKey string) (UserID, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", g.UserURL.String(), nil)
 	if err != nil {
-		return user, err
+		return "", err
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	res, err := client.Do(req)
 	if err != nil {
-		return user, err
+		return "", err
 	}
 
 	defer res.Body.Close()
-	err = json.NewDecoder(res.Body).Decode(&user)
-
-	return user, err
+	return GetUserID(res.Body, userIDKey)
 }

--- a/internal/provider/google_test.go
+++ b/internal/provider/google_test.go
@@ -141,8 +141,8 @@ func TestGoogleGetUser(t *testing.T) {
 		},
 	}
 
-	user, err := p.GetUser("123456789")
+	user, err := p.GetUser("123456789", "email")
 	assert.Nil(err)
 
-	assert.Equal("example@example.com", user.Email)
+	assert.Equal("example@example.com", user)
 }

--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"errors"
-
 	"github.com/coreos/go-oidc"
 	"golang.org/x/oauth2"
 )
@@ -81,19 +80,19 @@ func (o *OIDC) ExchangeCode(redirectURI, code string) (string, error) {
 }
 
 // GetUser uses the given token and returns a complete provider.User object
-func (o *OIDC) GetUser(token string) (User, error) {
-	var user User
+func (o *OIDC) GetUser(token, _ string) (UserID, error) {
 
 	// Parse & Verify ID Token
 	idToken, err := o.verifier.Verify(o.ctx, token)
 	if err != nil {
-		return user, err
+		return "", err
 	}
 
 	// Extract custom claims
+	var user User
 	if err := idToken.Claims(&user); err != nil {
-		return user, err
+		return "", err
 	}
 
-	return user, nil
+	return user.Email, nil
 }

--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -81,7 +81,6 @@ func (o *OIDC) ExchangeCode(redirectURI, code string) (string, error) {
 
 // GetUser uses the given token and returns a complete provider.User object
 func (o *OIDC) GetUser(token, _ string) (UserID, error) {
-
 	// Parse & Verify ID Token
 	idToken, err := o.verifier.Verify(o.ctx, token)
 	if err != nil {

--- a/internal/provider/oidc_test.go
+++ b/internal/provider/oidc_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2"
 )
 
 // Tests
@@ -122,9 +122,9 @@ func TestOIDCGetUser(t *testing.T) {
 	}`))
 
 	// Get user
-	user, err := provider.GetUser(token)
+	user, err := provider.GetUser(token, "")
 	assert.Nil(err)
-	assert.Equal("example@example.com", user.Email)
+	assert.Equal("example@example.com", user)
 }
 
 // Utils

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -48,7 +48,7 @@ func GetUserID(r io.Reader, key string) (UserID, error) {
 
 func GetKeyDataFromJson(json *gabs.Container, key string) (UserID, error) {
 	if !json.ExistsP(key) {
-		return "", errors.New("Invalid key: " + key)
+		return "", errors.New("Invalid key: " + key + " in json:" + string(json.Bytes()))
 	}
 	return fmt.Sprintf("%v", json.Path(key).Data()), nil
 }

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -23,7 +23,7 @@ type Provider interface {
 	Name() string
 	GetLoginURL(redirectURI, state string) string
 	ExchangeCode(redirectURI, code string) (string, error)
-	GetUser(token, userIDKey string) (string, error)
+	GetUser(token, userIDPath string) (string, error)
 	Setup() error
 }
 
@@ -36,21 +36,20 @@ type User struct {
 	Email string `json:"email"`
 }
 
+// UserID is a type used to represent a uniquely identified user
 type UserID = string
 
-func GetUserID(r io.Reader, key string) (UserID, error) {
-	jsonParsed, err := gabs.ParseJSONBuffer(r)
+// GetUserID extracts a UserID located at the (dot notation) path (userIDPath) in the json io.Reader
+func GetUserID(r io.Reader, userIDPath string) (UserID, error) {
+	json, err := gabs.ParseJSONBuffer(r)
 	if err != nil {
 		return "", err
 	}
-	return GetKeyDataFromJson(jsonParsed, key)
-}
 
-func GetKeyDataFromJson(json *gabs.Container, key string) (UserID, error) {
-	if !json.ExistsP(key) {
-		return "", errors.New("Invalid User ID Key: " + key + " in json:" + string(json.Bytes()))
+	if !json.ExistsP(userIDPath) {
+		return "", errors.New("Invalid User ID Path: " + userIDPath + " in json:" + string(json.Bytes()))
 	}
-	return fmt.Sprintf("%v", json.Path(key).Data()), nil
+	return fmt.Sprintf("%v", json.Path(userIDPath).Data()), nil
 }
 
 // OAuthProvider is a provider using the oauth2 library

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -43,14 +43,14 @@ func GetUserID(r io.Reader, key string) (UserID, error) {
 	if err != nil {
 		return "", err
 	}
-	return GetKeyDataFromContainer(jsonParsed, key)
+	return GetKeyDataFromJson(jsonParsed, key)
 }
 
-func GetKeyDataFromContainer(container *gabs.Container, key string) (UserID, error) {
-	if !container.ExistsP(key) {
+func GetKeyDataFromJson(json *gabs.Container, key string) (UserID, error) {
+	if !json.ExistsP(key) {
 		return "", errors.New("Invalid key: " + key)
 	}
-	return fmt.Sprintf("%v", container.Path(key).Data()), nil
+	return fmt.Sprintf("%v", json.Path(key).Data()), nil
 }
 
 // OAuthProvider is a provider using the oauth2 library

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -48,7 +48,7 @@ func GetUserID(r io.Reader, key string) (UserID, error) {
 
 func GetKeyDataFromJson(json *gabs.Container, key string) (UserID, error) {
 	if !json.ExistsP(key) {
-		return "", errors.New("Invalid key: " + key + " in json:" + string(json.Bytes()))
+		return "", errors.New("Invalid User ID Key: " + key + " in json:" + string(json.Bytes()))
 	}
 	return fmt.Sprintf("%v", json.Path(key).Data()), nil
 }

--- a/internal/server.go
+++ b/internal/server.go
@@ -164,7 +164,7 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		}
 
 		// Get user
-		user, err := p.GetUser(token, config.UserIDKey)
+		user, err := p.GetUser(token, config.UserIDPath)
 		if err != nil {
 			logger.WithField("error", err).Error("Error getting user")
 			http.Error(w, "Service unavailable", 503)

--- a/internal/server.go
+++ b/internal/server.go
@@ -88,7 +88,7 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 		}
 
 		// Validate cookie
-		email, err := ValidateCookie(r, c)
+		user, err := ValidateCookie(r, c)
 		if err != nil {
 			if err.Error() == "Cookie has expired" {
 				logger.Info("Cookie has expired")
@@ -101,16 +101,16 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 		}
 
 		// Validate user
-		valid := ValidateEmail(email)
+		valid := ValidateUser(user)
 		if !valid {
-			logger.WithField("email", email).Warn("Invalid email")
+			logger.WithField("user", user).Warn("Invalid user")
 			http.Error(w, "Not authorized", 401)
 			return
 		}
 
 		// Valid request
 		logger.Debug("Allowing valid request")
-		w.Header().Set("X-Forwarded-User", email)
+		w.Header().Set("X-Forwarded-User", user)
 		w.WriteHeader(200)
 	}
 }
@@ -172,11 +172,11 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		}
 
 		// Generate cookie
-		http.SetCookie(w, MakeCookie(r, user.Email))
+		http.SetCookie(w, MakeCookie(r, user))
 		logger.WithFields(logrus.Fields{
 			"provider": providerName,
 			"redirect": redirect,
-			"user":     user.Email,
+			"user":     user,
 		}).Info("Successfully generated auth cookie, redirecting user.")
 
 		// Redirect

--- a/internal/server.go
+++ b/internal/server.go
@@ -164,7 +164,7 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		}
 
 		// Get user
-		user, err := p.GetUser(token)
+		user, err := p.GetUser(token, config.UserIDKey)
 		if err != nil {
 			logger.WithField("error", err).Error("Error getting user")
 			http.Error(w, "Service unavailable", 503)


### PR DESCRIPTION
The callback of `PROVIDERS_GENERIC_OAUTH_USER_URL` returns the json:
```
{
  "avatar_url": "https://avatars0.githubusercontent.com/u/16902919?v=4",
  "bio": "Studying Computer Science with Artificial Intelligence at Sussex Uni. Passionate about product building.rn",
  "blog": "max.me.uk",
  "company": null,
  "created_at": "2016-01-26T17:01:55Z",
  "email": "max@max.me.uk",
  "events_url": "https://api.github.com/users/maxisme/events{/privacy}",
  "followers": 20,
  "followers_url": "https://api.github.com/users/maxisme/followers",
  "following": 42,
  "following_url": "https://api.github.com/users/maxisme/following{/other_user}",
  "gists_url": "https://api.github.com/users/maxisme/gists{/gist_id}",
  "gravatar_id": "",
  "hireable": false,
  "html_url": "https://github.com/maxisme",
  "id": 16902919,
  "location": "London, United Kingdom",
  "login": "maxisme",
  "name": "Maximilian Mitchell",
  "node_id": "MDQ6VXNlcjE2OTAyOTE5",
  "organizations_url": "https://api.github.com/users/maxisme/orgs",
  "public_gists": 1,
  "public_repos": 49,
  "received_events_url": "https://api.github.com/users/maxisme/received_events",
  "repos_url": "https://api.github.com/users/maxisme/repos",
  "site_admin": false,
  "starred_url": "https://api.github.com/users/maxisme/starred{/owner}{/repo}",
  "subscriptions_url": "https://api.github.com/users/maxisme/subscriptions",
  "twitter_username": "maxmeuk",
  "type": "User",
  "updated_at": "2020-08-01T12:56:35Z",
  "url": "https://api.github.com/users/maxisme"
}
```
This means I can specify `login` for the environment variable `USER_ID_PATH` (and co.) instead of the previously hardcoded and now default (`email`) and use that is my unique whitelist identifier.
 
This solves the problem of needing to expose your email as well.

I also:
 - Upgraded to Go 1.14  
 - Added to the README that you can comma separate the whitelists and domains as that isn't immediately obvious (and added test).
 - Added a GitHub action to test and deploy to docker (lmk if you want me to remove that)