### PR TITLE
Support concurrent CSRF cookies by using a prefix of nonce

### DIFF
--- a/internal/auth.go
+++ b/internal/auth.go
@@ -175,6 +175,10 @@ func buildCSRFCookieName(nonce string) string {
 }
 
 // MakeCSRFCookie makes a csrf cookie (used during login only)
+//
+// Note, CSRF cookies live shorter than auth cookies, a fixed 1h.
+// That's because some CSRF cookies may belong to auth flows that don't complete
+// and thus may not get cleared by ClearCookie.
 func MakeCSRFCookie(r *http.Request, nonce string) *http.Cookie {
 	return &http.Cookie{
 		Name:     buildCSRFCookieName(nonce),
@@ -183,7 +187,7 @@ func MakeCSRFCookie(r *http.Request, nonce string) *http.Cookie {
 		Domain:   csrfCookieDomain(r),
 		HttpOnly: true,
 		Secure:   !config.InsecureCookie,
-		Expires:  cookieExpiry(),
+		Expires:  time.Now().Local().Add(time.Hour * 1),
 	}
 }
 
@@ -201,12 +205,7 @@ func ClearCSRFCookie(r *http.Request, c *http.Cookie) *http.Cookie {
 }
 
 // FindCSRFCookie extracts the CSRF cookie from the request based on state.
-func FindCSRFCookie(r *http.Request) (c *http.Cookie, err error) {
-	state := r.URL.Query().Get("state")
-	if len(state) < 34 {
-		return nil, errors.New("Invalid CSRF state value")
-	}
-
+func FindCSRFCookie(r *http.Request, state string) (c *http.Cookie, err error) {
 	// Check for CSRF cookie
 	c, err = r.Cookie(buildCSRFCookieName(state))
 	if err != nil {
@@ -216,15 +215,9 @@ func FindCSRFCookie(r *http.Request) (c *http.Cookie, err error) {
 }
 
 // ValidateCSRFCookie validates the csrf cookie against state
-func ValidateCSRFCookie(r *http.Request, c *http.Cookie) (valid bool, provider string, redirect string, err error) {
-	state := r.URL.Query().Get("state")
-
+func ValidateCSRFCookie(c *http.Cookie, state string) (valid bool, provider string, redirect string, err error) {
 	if len(c.Value) != 32 {
 		return false, "", "", errors.New("Invalid CSRF cookie value")
-	}
-
-	if len(state) < 34 {
-		return false, "", "", errors.New("Invalid CSRF state value")
 	}
 
 	// Check nonce match
@@ -246,6 +239,14 @@ func ValidateCSRFCookie(r *http.Request, c *http.Cookie) (valid bool, provider s
 // MakeState generates a state value
 func MakeState(r *http.Request, p provider.Provider, nonce string) string {
 	return fmt.Sprintf("%s:%s:%s", nonce, p.Name(), returnUrl(r))
+}
+
+// ValidateState checks whether the state is of right length.
+func ValidateState(state string) error {
+	if len(state) < 34 {
+		return errors.New("Invalid CSRF state value")
+	}
+	return nil
 }
 
 // Nonce generates a random nonce

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -236,10 +236,12 @@ func TestAuthMakeCSRFCookie(t *testing.T) {
 }
 
 func TestAuthClearCSRFCookie(t *testing.T) {
+	assert := assert.New(t)
 	config, _ = NewConfig([]string{})
 	r, _ := http.NewRequest("GET", "http://example.com", nil)
 
-	c := ClearCSRFCookie(r)
+	c := ClearCSRFCookie(r, &http.Cookie{Name: "someCsrfCookie"})
+	assert.Equal("someCsrfCookie", c.Name)
 	if c.Value != "" {
 		t.Error("ClearCSRFCookie should create cookie with empty value")
 	}

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -1,7 +1,6 @@
 package tfa
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -251,54 +250,55 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 	assert := assert.New(t)
 	config, _ = NewConfig([]string{})
 	c := &http.Cookie{}
-
-	newCsrfRequest := func(state string) *http.Request {
-		u := fmt.Sprintf("http://example.com?state=%s", state)
-		r, _ := http.NewRequest("GET", u, nil)
-		return r
-	}
+	state := ""
 
 	// Should require 32 char string
-	r := newCsrfRequest("")
+	state = ""
 	c.Value = ""
-	valid, _, _, err := ValidateCSRFCookie(r, c)
+	valid, _, _, err := ValidateCSRFCookie(c, state)
 	assert.False(valid)
 	if assert.Error(err) {
 		assert.Equal("Invalid CSRF cookie value", err.Error())
 	}
 	c.Value = "123456789012345678901234567890123"
-	valid, _, _, err = ValidateCSRFCookie(r, c)
+	valid, _, _, err = ValidateCSRFCookie(c, state)
 	assert.False(valid)
 	if assert.Error(err) {
 		assert.Equal("Invalid CSRF cookie value", err.Error())
 	}
 
-	// Should require valid state
-	r = newCsrfRequest("12345678901234567890123456789012:")
-	c.Value = "12345678901234567890123456789012"
-	valid, _, _, err = ValidateCSRFCookie(r, c)
-	assert.False(valid)
-	if assert.Error(err) {
-		assert.Equal("Invalid CSRF state value", err.Error())
-	}
-
 	// Should require provider
-	r = newCsrfRequest("12345678901234567890123456789012:99")
+	state = "12345678901234567890123456789012:99"
 	c.Value = "12345678901234567890123456789012"
-	valid, _, _, err = ValidateCSRFCookie(r, c)
+	valid, _, _, err = ValidateCSRFCookie(c, state)
 	assert.False(valid)
 	if assert.Error(err) {
 		assert.Equal("Invalid CSRF state format", err.Error())
 	}
 
 	// Should allow valid state
-	r = newCsrfRequest("12345678901234567890123456789012:p99:url123")
+	state = "12345678901234567890123456789012:p99:url123"
 	c.Value = "12345678901234567890123456789012"
-	valid, provider, redirect, err := ValidateCSRFCookie(r, c)
+	valid, provider, redirect, err := ValidateCSRFCookie(c, state)
 	assert.True(valid, "valid request should return valid")
 	assert.Nil(err, "valid request should not return an error")
 	assert.Equal("p99", provider, "valid request should return correct provider")
 	assert.Equal("url123", redirect, "valid request should return correct redirect")
+}
+
+func TestValidateState(t *testing.T) {
+	assert := assert.New(t)
+
+	// Should require valid state
+	state := "12345678901234567890123456789012:"
+	err := ValidateState(state)
+	if assert.Error(err) {
+		assert.Equal("Invalid CSRF state value", err.Error())
+	}
+	// Should pass this state
+	state = "12345678901234567890123456789012:p99:url123"
+	err = ValidateState(state)
+	assert.Nil(err, "valid request should not return an error")
 }
 
 func TestMakeState(t *testing.T) {

--- a/internal/server.go
+++ b/internal/server.go
@@ -122,7 +122,7 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		logger := s.logger(r, "AuthCallback", "default", "Handling callback")
 
 		// Check for CSRF cookie
-		c, err := r.Cookie(config.CSRFCookieName)
+		c, err := FindCSRFCookie(r)
 		if err != nil {
 			logger.Info("Missing csrf cookie")
 			http.Error(w, "Not authorized", 401)
@@ -153,7 +153,7 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		}
 
 		// Clear CSRF cookie
-		http.SetCookie(w, ClearCSRFCookie(r))
+		http.SetCookie(w, ClearCSRFCookie(r, c))
 
 		// Exchange code for token
 		token, err := p.ExchangeCode(redirectUri(r), r.URL.Query().Get("code"))

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -98,7 +98,7 @@ func TestServerAuthHandlerExpired(t *testing.T) {
 	// Check for CSRF cookie
 	var cookie *http.Cookie
 	for _, c := range res.Cookies() {
-		if c.Name == config.CSRFCookieName {
+		if strings.HasPrefix(c.Name, config.CSRFCookieName) {
 			cookie = c
 		}
 	}


### PR DESCRIPTION
This addresses the problem of multiple login requests (with different nonces in state) rewriting the same CSRF cookie. 
It provides a unique cookie per request by suffixing the CSRF cookie name with the first 6 characters of the nonce, e.g. `_forward_auth_csrf_986711`.

This should address #176 and #113 


I've verified that it works in my local setup, and addresses the issue of using Traefik Forward Auth in front of single page apps such as Home Assistant.