### PR TITLE
Add GitHub Actions workflow for creating binaries for releases (#184)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,8 @@ jobs:
     name: Build release binaries
     runs-on: ubuntu-latest
     steps:
-    
-    - name: Install jq and curl
-      run: sudo apt-get install jq curl
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -20,33 +19,29 @@ jobs:
         go-version: ^1.13
       id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
-
     - name: Build AMD64
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -installsuffix nocgo -v -o traefik-forward-auth_amd64 ./cmd
 
     - name: Build ARM
       run: CGO_ENABLED=0 GOOS=linux GOARCH=arm GO111MODULE=on go build -a -installsuffix nocgo -v -o traefik-forward-auth_arm ./cmd
 
-    - name: Get release details
+    - name: Get tag name
+      run: echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Get artifact details
+      uses: octokit/request-action@v2.x
       id: get_release_details
-      run: echo "::set-output name=upload_url::$(curl https://api.github.com/repos/${{ github.repository }}/releases/tags/$(echo '${{ github.ref }}' | cut -d '/' -f 3 ) | jq '.upload_url' -r)"
-    
+      with:
+        route: get /repos/${{ github.repository }}/releases/tags/${{ env.TAG }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Upload AMD64 release asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.get_release_details.outputs.upload_url }}
+        upload_url: ${{ fromJson(steps.get_release_details.outputs.data).upload_url }}
         asset_path: traefik-forward-auth_amd64
         asset_name: traefik-forward-auth_amd64
         asset_content_type: application/octet-stream
@@ -56,7 +51,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.get_release_details.outputs.upload_url }}
+        upload_url: ${{ fromJson(steps.get_release_details.outputs.data).upload_url }}
         asset_path: traefik-forward-auth_arm
         asset_name: traefik-forward-auth_arm
         asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  build:
+    name: Build release binaries
+    runs-on: ubuntu-latest
+    steps:
+    
+    - name: Install jq and curl
+      run: sudo apt-get install jq curl
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build AMD64
+      run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -installsuffix nocgo -v -o traefik-forward-auth_amd64 ./cmd
+
+    - name: Build ARM
+      run: CGO_ENABLED=0 GOOS=linux GOARCH=arm GO111MODULE=on go build -a -installsuffix nocgo -v -o traefik-forward-auth_arm ./cmd
+
+    - name: Get release details
+      id: get_release_details
+      run: echo "::set-output name=upload_url::$(curl https://api.github.com/repos/${{ github.repository }}/releases/tags/$(echo '${{ github.ref }}' | cut -d '/' -f 3 ) | jq '.upload_url' -r)"
+    
+    - name: Upload AMD64 release asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_details.outputs.upload_url }}
+        asset_path: traefik-forward-auth_amd64
+        asset_name: traefik-forward-auth_amd64
+        asset_content_type: application/octet-stream
+
+    - name: Upload ARM release asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_details.outputs.upload_url }}
+        asset_path: traefik-forward-auth_arm
+        asset_name: traefik-forward-auth_arm
+        asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ You can also use the latest incremental releases found on [docker hub](https://h
 
 ARM releases are also available on docker hub, just append `-arm` or `-arm64` to your desired released (e.g. `2-arm` or `2.1-arm64`).
 
+We also build binary files for usage without docker starting with releases after 2.2.0 You can find these as assets of the specific GitHub release.
+
 #### Upgrade Guide
 
 v2 was released in June 2019, whilst this is fully backwards compatible, a number of configuration options were modified, please see the [upgrade guide](https://github.com/thomseddon/traefik-forward-auth/wiki/v2-Upgrade-Guide) to prevent warnings on startup and ensure you are using the current configuration.


### PR DESCRIPTION
With this pull request GitHub Actions will create binary files for future releases. These are good for a usage without Docker.

I created an example release, if you want to have a look on it: https://github.com/em0lar/traefik-forward-auth/releases/tag/v2.2.0-test

I'm open to any recommendations from you!
closes #184 