### PR TITLE
Allow to be run without middleware + improve request reading consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,8 +423,6 @@ spec:
       - name: traefik-forward-auth
 ```
 
-Note: If using auth host mode, you must apply the middleware to your auth host ingress.
-
 See the examples directory for more examples.
 
 #### Selective Container Authentication in Swarm
@@ -438,8 +436,6 @@ whoami:
     - "traefik.http.routers.whoami.rule=Host(`whoami.example.com`)"
     - "traefik.http.routers.whoami.middlewares=traefik-forward-auth"
 ```
-
-Note: If using auth host mode, you must apply the middleware to the traefik-forward-auth container.
 
 See the examples directory for more examples.
 

--- a/examples/traefik-v2/kubernetes/advanced-separate-pod/traefik-forward-auth/ingress.yaml
+++ b/examples/traefik-v2/kubernetes/advanced-separate-pod/traefik-forward-auth/ingress.yaml
@@ -16,7 +16,5 @@ spec:
     services:
     - name: traefik-forward-auth
       port: 4181
-    middlewares:
-      - name: traefik-forward-auth
   tls:
     certresolver: default

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -2,6 +2,7 @@ package tfa
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -196,10 +197,8 @@ func TestAuthValidateEmail(t *testing.T) {
 func TestRedirectUri(t *testing.T) {
 	assert := assert.New(t)
 
-	r, _ := http.NewRequest("GET", "http://example.com", nil)
+	r := httptest.NewRequest("GET", "http://app.example.com/hello", nil)
 	r.Header.Add("X-Forwarded-Proto", "http")
-	r.Header.Add("X-Forwarded-Host", "app.example.com")
-	r.Header.Add("X-Forwarded-Uri", "/hello")
 
 	//
 	// No Auth Host
@@ -241,10 +240,8 @@ func TestRedirectUri(t *testing.T) {
 	// With Auth URL + cookie domain, but from different domain
 	// - will not use auth host
 	//
-	r, _ = http.NewRequest("GET", "http://another.com", nil)
+	r = httptest.NewRequest("GET", "https://another.com/hello", nil)
 	r.Header.Add("X-Forwarded-Proto", "https")
-	r.Header.Add("X-Forwarded-Host", "another.com")
-	r.Header.Add("X-Forwarded-Uri", "/hello")
 
 	config.AuthHost = "auth.example.com"
 	config.CookieDomains = []CookieDomain{*NewCookieDomain("example.com")}
@@ -378,10 +375,8 @@ func TestValidateState(t *testing.T) {
 func TestMakeState(t *testing.T) {
 	assert := assert.New(t)
 
-	r, _ := http.NewRequest("GET", "http://example.com", nil)
+	r := httptest.NewRequest("GET", "http://example.com/hello", nil)
 	r.Header.Add("X-Forwarded-Proto", "http")
-	r.Header.Add("X-Forwarded-Host", "example.com")
-	r.Header.Add("X-Forwarded-Uri", "/hello")
 
 	// Test with google
 	p := provider.Google{}

--- a/internal/server.go
+++ b/internal/server.go
@@ -58,7 +58,11 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 	// Modify request
 	r.Method = r.Header.Get("X-Forwarded-Method")
 	r.Host = r.Header.Get("X-Forwarded-Host")
-	r.URL, _ = url.Parse(r.Header.Get("X-Forwarded-Uri"))
+
+	// Read URI from header if we're acting as forward auth middleware
+	if _, ok := r.Header["X-Forwarded-Uri"]; ok {
+		r.URL, _ = url.Parse(r.Header.Get("X-Forwarded-Uri"))
+	}
 
 	// Pass to mux
 	s.router.ServeHTTP(w, r)


### PR DESCRIPTION
Prior to this change, the request URI was only ever read from the X-Forwarded-Uri header which was only set when the container was accessed via the forwardauth middleware. As such, it was necessary to apply the treafik-forward-auth middleware to the treafik-forward-auth container when running auth host mode.

This is a quirk, unnecessary complexity and is a frequent source of configuration issues.