### PR TITLE
Make OAuth2 AuthStyle configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ OIDC Provider:
   --providers.oidc.client-id=                           Client ID [$PROVIDERS_OIDC_CLIENT_ID]
   --providers.oidc.client-secret=                       Client Secret [$PROVIDERS_OIDC_CLIENT_SECRET]
   --providers.oidc.resource=                            Optional resource indicator [$PROVIDERS_OIDC_RESOURCE]
+  --providers.oidc.auth-type=                           Optionally choose the authentication type of the OAuth2 library
+    [auto-detect, header, params]                       (default: auto-detect) [$PROVIDERS_OIDC_AUTH_TYPE]
 
 Generic OAuth2 Provider:
   --providers.generic-oauth.auth-url=                   Auth/Login URL [$PROVIDERS_GENERIC_OAUTH_AUTH_URL]
@@ -188,6 +190,8 @@ Generic OAuth2 Provider:
   --providers.generic-oauth.token-style=[header|query]  How token is presented when querying the User URL (default: header)
                                                         [$PROVIDERS_GENERIC_OAUTH_TOKEN_STYLE]
   --providers.generic-oauth.resource=                   Optional resource indicator [$PROVIDERS_GENERIC_OAUTH_RESOURCE]
+  --providers.generic-oauth.auth-type=                  Optionally choose the authentication type of the OAuth2 library
+    [auto-detect, header, params]                       (default: auto-detect) [$PROVIDERS_GENERIC_OAUTH_AUTH_TYPE]
 
 Help Options:
   -h, --help                                            Show this help message

--- a/internal/provider/generic_oauth.go
+++ b/internal/provider/generic_oauth.go
@@ -41,7 +41,7 @@ func (o *GenericOAuth) Setup() error {
 		ClientID:     o.ClientID,
 		ClientSecret: o.ClientSecret,
 		Endpoint: oauth2.Endpoint{
-			AuthStyle: o.GetAuthStyle(),
+			AuthStyle: parseAuthStyle(o.AuthStyle),
 			AuthURL:  o.AuthURL,
 			TokenURL: o.TokenURL,
 		},
@@ -51,17 +51,6 @@ func (o *GenericOAuth) Setup() error {
 	o.ctx = context.Background()
 
 	return nil
-}
-
-func (o *GenericOAuth) GetAuthStyle() oauth2.AuthStyle {
-	switch o.AuthStyle {
-	case "header":
-		return oauth2.AuthStyleInHeader
-	case "params":
-		return oauth2.AuthStyleInParams
-	default:
-		return oauth2.AuthStyleAutoDetect
-	}
 }
 
 // GetLoginURL provides the login url for the given redirect uri and state

--- a/internal/provider/generic_oauth.go
+++ b/internal/provider/generic_oauth.go
@@ -18,6 +18,7 @@ type GenericOAuth struct {
 	ClientID     string   `long:"client-id" env:"CLIENT_ID" description:"Client ID"`
 	ClientSecret string   `long:"client-secret" env:"CLIENT_SECRET" description:"Client Secret" json:"-"`
 	Scopes       []string `long:"scope" env:"SCOPE" env-delim:"," default:"profile" default:"email" description:"Scopes"`
+	AuthStyle	 string	  `long:"auth-style" env:"AUTH_STYLE" default:"auto-detect" choice:"auto-detect" choice:"header" choice:"params" description:"Authentication style to be used by the OAuth library"`
 	TokenStyle   string   `long:"token-style" env:"TOKEN_STYLE" default:"header" choice:"header" choice:"query" description:"How token is presented when querying the User URL"`
 
 	OAuthProvider
@@ -40,6 +41,7 @@ func (o *GenericOAuth) Setup() error {
 		ClientID:     o.ClientID,
 		ClientSecret: o.ClientSecret,
 		Endpoint: oauth2.Endpoint{
+			AuthStyle: o.GetAuthStyle(),
 			AuthURL:  o.AuthURL,
 			TokenURL: o.TokenURL,
 		},
@@ -49,6 +51,17 @@ func (o *GenericOAuth) Setup() error {
 	o.ctx = context.Background()
 
 	return nil
+}
+
+func (o *GenericOAuth) GetAuthStyle() oauth2.AuthStyle {
+	switch o.AuthStyle {
+	case "header":
+		return oauth2.AuthStyleInHeader
+	case "params":
+		return oauth2.AuthStyleInParams
+	default:
+		return oauth2.AuthStyleAutoDetect
+	}
 }
 
 // GetLoginURL provides the login url for the given redirect uri and state

--- a/internal/provider/generic_oauth.go
+++ b/internal/provider/generic_oauth.go
@@ -18,7 +18,7 @@ type GenericOAuth struct {
 	ClientID     string   `long:"client-id" env:"CLIENT_ID" description:"Client ID"`
 	ClientSecret string   `long:"client-secret" env:"CLIENT_SECRET" description:"Client Secret" json:"-"`
 	Scopes       []string `long:"scope" env:"SCOPE" env-delim:"," default:"profile" default:"email" description:"Scopes"`
-	AuthStyle	 string	  `long:"auth-style" env:"AUTH_STYLE" default:"auto-detect" choice:"auto-detect" choice:"header" choice:"params" description:"Authentication style to be used by the OAuth library"`
+	AuthStyle    string   `long:"auth-style" env:"AUTH_STYLE" default:"auto-detect" choice:"auto-detect" choice:"header" choice:"params" description:"Authentication style to be used by the OAuth library"`
 	TokenStyle   string   `long:"token-style" env:"TOKEN_STYLE" default:"header" choice:"header" choice:"query" description:"How token is presented when querying the User URL"`
 
 	OAuthProvider

--- a/internal/provider/generic_oauth_test.go
+++ b/internal/provider/generic_oauth_test.go
@@ -60,7 +60,7 @@ func TestGenericOAuthGetAuthStyleDefault(t *testing.T) {
 func TestGenericOAuthGetAuthStyleHeader(t *testing.T) {
 	assert := assert.New(t)
 	p := GenericOAuth{
-		AuthStyle: 	  "header",
+		AuthStyle:    "header",
 		AuthURL:      "https://provider.com/oauth2/auth",
 		TokenURL:     "https://provider.com/oauth2/token",
 		UserURL:      "https://provider.com/oauth2/user",
@@ -81,7 +81,7 @@ func TestGenericOAuthGetAuthStyleHeader(t *testing.T) {
 func TestGenericOAuthGetAuthStyleParams(t *testing.T) {
 	assert := assert.New(t)
 	p := GenericOAuth{
-		AuthStyle: 	  "params",
+		AuthStyle:    "params",
 		AuthURL:      "https://provider.com/oauth2/auth",
 		TokenURL:     "https://provider.com/oauth2/token",
 		UserURL:      "https://provider.com/oauth2/user",

--- a/internal/provider/generic_oauth_test.go
+++ b/internal/provider/generic_oauth_test.go
@@ -1,11 +1,11 @@
 package provider
 
 import (
+	"golang.org/x/oauth2"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/oauth2"
 )
 
 // Tests
@@ -35,6 +35,68 @@ func TestGenericOAuthSetup(t *testing.T) {
 	}
 	err = p.Setup()
 	assert.Nil(err)
+}
+
+func TestGenericOAuthGetAuthStyleDefault(t *testing.T) {
+	assert := assert.New(t)
+	p := GenericOAuth{
+		AuthURL:      "https://provider.com/oauth2/auth",
+		TokenURL:     "https://provider.com/oauth2/token",
+		UserURL:      "https://provider.com/oauth2/user",
+		ClientID:     "idtest",
+		ClientSecret: "secret",
+		Scopes:       []string{"scopetest"},
+	}
+
+	err := p.Setup()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authStyle := p.GetAuthStyle()
+	assert.Equal(oauth2.AuthStyleAutoDetect, authStyle)
+}
+
+func TestGenericOAuthGetAuthStyleHeader(t *testing.T) {
+	assert := assert.New(t)
+	p := GenericOAuth{
+		AuthStyle: 	  "header",
+		AuthURL:      "https://provider.com/oauth2/auth",
+		TokenURL:     "https://provider.com/oauth2/token",
+		UserURL:      "https://provider.com/oauth2/user",
+		ClientID:     "idtest",
+		ClientSecret: "secret",
+		Scopes:       []string{"scopetest"},
+	}
+
+	err := p.Setup()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authStyle := p.GetAuthStyle()
+	assert.Equal(oauth2.AuthStyleInHeader, authStyle)
+}
+
+func TestGenericOAuthGetAuthStyleParams(t *testing.T) {
+	assert := assert.New(t)
+	p := GenericOAuth{
+		AuthStyle: 	  "params",
+		AuthURL:      "https://provider.com/oauth2/auth",
+		TokenURL:     "https://provider.com/oauth2/token",
+		UserURL:      "https://provider.com/oauth2/user",
+		ClientID:     "idtest",
+		ClientSecret: "secret",
+		Scopes:       []string{"scopetest"},
+	}
+
+	err := p.Setup()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authStyle := p.GetAuthStyle()
+	assert.Equal(oauth2.AuthStyleInParams, authStyle)
 }
 
 func TestGenericOAuthGetLoginURL(t *testing.T) {
@@ -89,6 +151,9 @@ func TestGenericOAuthExchangeCode(t *testing.T) {
 
 	// Setup provider
 	p := GenericOAuth{
+		// We force AuthStyleInParams to prevent the test failure when the
+		// AuthStyleInHeader is attempted
+		AuthStyle: 	  "params",
 		AuthURL:      "https://provider.com/oauth2/auth",
 		TokenURL:     serverURL.String() + "/token",
 		UserURL:      "https://provider.com/oauth2/user",
@@ -99,10 +164,6 @@ func TestGenericOAuthExchangeCode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// We force AuthStyleInParams to prevent the test failure when the
-	// AuthStyleInHeader is attempted
-	p.Config.Endpoint.AuthStyle = oauth2.AuthStyleInParams
 
 	token, err := p.ExchangeCode("http://example.com/_oauth", "code")
 	assert.Nil(err)
@@ -118,6 +179,9 @@ func TestGenericOAuthGetUser(t *testing.T) {
 
 	// Setup provider
 	p := GenericOAuth{
+		// We force AuthStyleInParams to prevent the test failure when the
+		// AuthStyleInHeader is attempted
+		AuthStyle: 	  "params",
 		AuthURL:      "https://provider.com/oauth2/auth",
 		TokenURL:     "https://provider.com/oauth2/token",
 		UserURL:      serverURL.String() + "/userinfo",
@@ -128,10 +192,6 @@ func TestGenericOAuthGetUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// We force AuthStyleInParams to prevent the test failure when the
-	// AuthStyleInHeader is attempted
-	p.Config.Endpoint.AuthStyle = oauth2.AuthStyleInParams
 
 	user, err := p.GetUser("123456789")
 	assert.Nil(err)

--- a/internal/provider/generic_oauth_test.go
+++ b/internal/provider/generic_oauth_test.go
@@ -53,7 +53,7 @@ func TestGenericOAuthGetAuthStyleDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	authStyle := p.GetAuthStyle()
+	authStyle := parseAuthStyle(p.AuthStyle)
 	assert.Equal(oauth2.AuthStyleAutoDetect, authStyle)
 }
 
@@ -74,7 +74,7 @@ func TestGenericOAuthGetAuthStyleHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	authStyle := p.GetAuthStyle()
+	authStyle := parseAuthStyle(p.AuthStyle)
 	assert.Equal(oauth2.AuthStyleInHeader, authStyle)
 }
 
@@ -95,7 +95,7 @@ func TestGenericOAuthGetAuthStyleParams(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	authStyle := p.GetAuthStyle()
+	authStyle := parseAuthStyle(p.AuthStyle)
 	assert.Equal(oauth2.AuthStyleInParams, authStyle)
 }
 

--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -13,7 +13,7 @@ type OIDC struct {
 	IssuerURL    string `long:"issuer-url" env:"ISSUER_URL" description:"Issuer URL"`
 	ClientID     string `long:"client-id" env:"CLIENT_ID" description:"Client ID"`
 	ClientSecret string `long:"client-secret" env:"CLIENT_SECRET" description:"Client Secret" json:"-"`
-	AuthStyle 	 string	`long:"auth-style" env:"AUTH_STYLE" default:"auto-detect" choice:"auto-detect" choice:"header" choice:"params" description:"Authentication style to be used by the OAuth library"`
+	AuthStyle    string `long:"auth-style" env:"AUTH_STYLE" default:"auto-detect" choice:"auto-detect" choice:"header" choice:"params" description:"Authentication style to be used by the OAuth library"`
 
 	OAuthProvider
 

--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -47,7 +47,7 @@ func (o *OIDC) Setup() error {
 		ClientID:     o.ClientID,
 		ClientSecret: o.ClientSecret,
 		Endpoint: oauth2.Endpoint{
-			AuthStyle: o.GetAuthStyle(),
+			AuthStyle: parseAuthStyle(o.AuthStyle),
 			AuthURL:  o.provider.Endpoint().AuthURL,
 			TokenURL: o.provider.Endpoint().TokenURL,
 		},
@@ -62,17 +62,6 @@ func (o *OIDC) Setup() error {
 	})
 
 	return nil
-}
-
-func (o *OIDC) GetAuthStyle() oauth2.AuthStyle {
-	switch o.AuthStyle {
-	case "header":
-		return oauth2.AuthStyleInHeader
-	case "params":
-		return oauth2.AuthStyleInParams
-	default:
-		return oauth2.AuthStyleAutoDetect
-	}
 }
 
 // GetLoginURL provides the login url for the given redirect uri and state

--- a/internal/provider/oidc_test.go
+++ b/internal/provider/oidc_test.go
@@ -40,7 +40,7 @@ func TestOIDCGetAuthStyleAutoDetect(t *testing.T) {
 	assert := assert.New(t)
 	provider, _, _, _ := setupOIDCTest(t, nil, defaultAuthStyle)
 
-	authStyle := provider.GetAuthStyle()
+	authStyle := parseAuthStyle(provider.AuthStyle)
 	assert.Equal(oauth2.AuthStyleAutoDetect, authStyle)
 }
 
@@ -48,7 +48,7 @@ func TestOIDCGetAuthStyleHeader(t *testing.T) {
 	assert := assert.New(t)
 	provider, _, _, _ := setupOIDCTest(t, nil, "header")
 
-	authStyle := provider.GetAuthStyle()
+	authStyle := parseAuthStyle(provider.AuthStyle)
 	assert.Equal(oauth2.AuthStyleInHeader, authStyle)
 }
 
@@ -56,7 +56,7 @@ func TestOIDCGetAuthStyleParams(t *testing.T) {
 	assert := assert.New(t)
 	provider, _, _, _ := setupOIDCTest(t, nil, "params")
 
-	authStyle := provider.GetAuthStyle()
+	authStyle := parseAuthStyle(provider.AuthStyle)
 	assert.Equal(oauth2.AuthStyleInParams, authStyle)
 }
 

--- a/internal/provider/oidc_test.go
+++ b/internal/provider/oidc_test.go
@@ -181,7 +181,7 @@ func setupOIDCTest(t *testing.T, bodyValues map[string]map[string]string, authSt
 
 	// Setup provider
 	p := OIDC{
-		AuthStyle:	  authStyle,
+		AuthStyle:    authStyle,
 		ClientID:     "idtest",
 		ClientSecret: "sectest",
 		IssuerURL:    serverURL.String(),

--- a/internal/provider/oidc_test.go
+++ b/internal/provider/oidc_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
+	"golang.org/x/oauth2"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,8 @@ import (
 )
 
 // Tests
+
+var defaultAuthStyle = "auto-detect"
 
 func TestOIDCName(t *testing.T) {
 	p := OIDC{}
@@ -33,10 +36,34 @@ func TestOIDCSetup(t *testing.T) {
 	}
 }
 
+func TestOIDCGetAuthStyleAutoDetect(t *testing.T) {
+	assert := assert.New(t)
+	provider, _, _, _ := setupOIDCTest(t, nil, defaultAuthStyle)
+
+	authStyle := provider.GetAuthStyle()
+	assert.Equal(oauth2.AuthStyleAutoDetect, authStyle)
+}
+
+func TestOIDCGetAuthStyleHeader(t *testing.T) {
+	assert := assert.New(t)
+	provider, _, _, _ := setupOIDCTest(t, nil, "header")
+
+	authStyle := provider.GetAuthStyle()
+	assert.Equal(oauth2.AuthStyleInHeader, authStyle)
+}
+
+func TestOIDCGetAuthStyleParams(t *testing.T) {
+	assert := assert.New(t)
+	provider, _, _, _ := setupOIDCTest(t, nil, "params")
+
+	authStyle := provider.GetAuthStyle()
+	assert.Equal(oauth2.AuthStyleInParams, authStyle)
+}
+
 func TestOIDCGetLoginURL(t *testing.T) {
 	assert := assert.New(t)
 
-	provider, server, serverURL, _ := setupOIDCTest(t, nil)
+	provider, server, serverURL, _ := setupOIDCTest(t, nil, defaultAuthStyle)
 	defer server.Close()
 
 	// Check url
@@ -97,7 +124,7 @@ func TestOIDCExchangeCode(t *testing.T) {
 			"grant_type":   "authorization_code",
 			"redirect_uri": "http://example.com/_oauth",
 		},
-	})
+	}, defaultAuthStyle)
 	defer server.Close()
 
 	token, err := provider.ExchangeCode("http://example.com/_oauth", "code")
@@ -108,7 +135,7 @@ func TestOIDCExchangeCode(t *testing.T) {
 func TestOIDCGetUser(t *testing.T) {
 	assert := assert.New(t)
 
-	provider, server, serverURL, key := setupOIDCTest(t, nil)
+	provider, server, serverURL, key := setupOIDCTest(t, nil, defaultAuthStyle)
 	defer server.Close()
 
 	// Generate JWT
@@ -130,7 +157,7 @@ func TestOIDCGetUser(t *testing.T) {
 // Utils
 
 // setOIDCTest creates a key, OIDCServer and initilises an OIDC provider
-func setupOIDCTest(t *testing.T, bodyValues map[string]map[string]string) (*OIDC, *httptest.Server, *url.URL, *rsaKey) {
+func setupOIDCTest(t *testing.T, bodyValues map[string]map[string]string, authStyle string) (*OIDC, *httptest.Server, *url.URL, *rsaKey) {
 	// Generate key
 	key, err := newRSAKey()
 	if err != nil {
@@ -154,6 +181,7 @@ func setupOIDCTest(t *testing.T, bodyValues map[string]map[string]string) (*OIDC
 
 	// Setup provider
 	p := OIDC{
+		AuthStyle:	  authStyle,
 		ClientID:     "idtest",
 		ClientSecret: "sectest",
 		IssuerURL:    serverURL.String(),

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -40,6 +40,17 @@ type OAuthProvider struct {
 	ctx    context.Context
 }
 
+func parseAuthStyle(authStyle string) oauth2.AuthStyle {
+	switch authStyle {
+	case "header":
+		return oauth2.AuthStyleInHeader
+	case "params":
+		return oauth2.AuthStyleInParams
+	default:
+		return oauth2.AuthStyleAutoDetect
+	}
+}
+
 // ConfigCopy returns a copy of the oauth2 config with the given redirectURI
 // which ensures the underlying config is not modified
 func (p *OAuthProvider) ConfigCopy(redirectURI string) oauth2.Config {


### PR DESCRIPTION
As stated in https://github.com/thomseddon/traefik-forward-auth/issues/259 some OIDC/OAuth providers don't work with the `auto-detect` AuthStyle of golang's OAuth library.

This pull request makes the AuthStyle that `traefik-forward-auth` configurable so that it can be adjusted when used with providers like AWS Cognito.