### PR TITLE
Domain matching should be case insensitive

### DIFF
--- a/internal/auth.go
+++ b/internal/auth.go
@@ -113,8 +113,9 @@ func ValidateDomains(email string, domains CommaSeparatedList) bool {
 	if len(parts) < 2 {
 		return false
 	}
+	emailDomain := strings.ToLower(parts[1])
 	for _, domain := range domains {
-		if domain == parts[1] {
+		if domain == emailDomain {
 			return true
 		}
 	}

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -79,6 +79,11 @@ func TestAuthValidateEmail(t *testing.T) {
 	v = ValidateEmail("test@test.com", "default")
 	assert.True(v, "should allow user from allowed domain")
 
+	// Should match regardless of domain case
+	config.Domains = []string{"test.com"}
+	v = ValidateEmail("test@TeSt.com", "default")
+	assert.True(v, "should allow user from allowed domain, regardless of case")
+
 	// Should allow matching whitelisted email address
 	config.Domains = []string{}
 	config.Whitelist = []string{"test@test.com"}


### PR DESCRIPTION
For some reason, when authenticating via Azure AD / Microsoft 365 for our org, some email addresses have domains with capitalisation. This PR addresses this issue and ensures that the domain part of the email is lowercased before comparing.