### PR TITLE
Allow users to escape 'Not authorized' when their email address is now found on the allow-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,12 @@ All options can be supplied in any of the following ways, in the following prece
 
    Please note that when using the default [Overlay Mode](#overlay-mode) requests to this exact path will be intercepted by this service and not forwarded to your application. Use this option (or [Auth Host Mode](#auth-host-mode)) if the default `/_oauth` path will collide with an existing route in your application.
 
+- `logout-if-invalid-email`
+
+   When enabled, logs out users if their email address isn't found on the allow list, allowing them to retry with another email address.
+
+   Default: `false`
+
 - `secret`
 
    Used to sign cookies authentication, should be a random (e.g. `openssl rand -hex 16`)

--- a/internal/config.go
+++ b/internal/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	SecretString           string               `long:"secret" env:"SECRET" description:"Secret used for signing (required)" json:"-"`
 	Whitelist              CommaSeparatedList   `long:"whitelist" env:"WHITELIST" env-delim:"," description:"Only allow given email addresses, can be set multiple times"`
 	Port                   int                  `long:"port" env:"PORT" default:"4181" description:"Port to listen on"`
+	LogoutIfInvalidEmail   bool                 `long:"logout-if-invalid-email" env:"LOGOUT_IF_INVALID_EMAIL" default:"false" description:"Allow user to retry another email address if their email address isn't found on the allow list"`
 
 	Providers provider.Providers `group:"providers" namespace:"providers" env-namespace:"PROVIDERS"`
 	Rules     map[string]*Rule   `long:"rule.<name>.<param>" description:"Rule definitions, param can be: \"action\", \"rule\" or \"provider\""`

--- a/internal/server.go
+++ b/internal/server.go
@@ -108,7 +108,15 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 		valid := ValidateEmail(email, rule)
 		if !valid {
 			logger.WithField("email", email).Warn("Invalid email")
-			http.Error(w, "Not authorized", 401)
+
+			if config.LogoutIfInvalidEmail == true {
+				// The email address isn't valid so display an error and clear the cookie
+				// Clearing the cookie will allow the user to try another email address and avoid being trapped on 'Not authorized'
+				http.SetCookie(w, ClearCookie(r))
+				http.Error(w, "Not authorized (Refresh to try again with a different email address)", 401)
+			}else {
+				http.Error(w, "Not authorized", 401)
+			}
 			return
 		}
 


### PR DESCRIPTION
Hi, love the project and thanks for maintaining @thomseddon

Okay so, I've run into an issue where a user will authenticate with an erroneous email address and then be stuck on 'Not authorized', I don't think it's anything new, and the issue seems well documented with #147 and #103 

The current workflow for remedying the issue currently seems to be to clear your auth cookie manually which is a little bit awkward for end-users.

My goal with this pull request was to create a more user-friendly workflow for allowing the user to retry with a new email address, without degrading any security features of the project.

My intention was as follows:

1. Find the point where a user's email address is checked against the allow list
2. Clear the auth cookie with as much pre-existing code as possible (using the existing ClearCookie function)
3. Give the user feedback, prompting them to try again
4. Set up a config flag that allows for this feature to be turned on or off
5. Default this feature to off as to not affect existing workflows

This is my first time touching Go, so definitely check over my changes.

Thanks again,
Luis