### PR TITLE
allow preserving the originally requested path after the authentication redirect

### DIFF
--- a/internal/auth.go
+++ b/internal/auth.go
@@ -128,9 +128,10 @@ func redirectBase(r *http.Request) string {
 	return fmt.Sprintf("%s://%s", r.Header.Get("X-Forwarded-Proto"), r.Host)
 }
 
-// Return url
+// returnUrl is the URL that we will return to after authentication. Uses `RequestURI()` in order
+// to preserve both the path and query parameters.
 func returnUrl(r *http.Request) string {
-	return fmt.Sprintf("%s%s", redirectBase(r), r.URL.Path)
+	return fmt.Sprintf("%s%s", redirectBase(r), r.URL.RequestURI())
 }
 
 // Get oauth redirect uri

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -392,6 +392,23 @@ func TestMakeState(t *testing.T) {
 	p3 := provider.GenericOAuth{}
 	state = MakeState(r, &p3, "nonce")
 	assert.Equal("nonce:generic-oauth:http://example.com/hello", state)
+
+	// Test at the root, but with a forwarded prefix
+	// this is how traefik forwards the request path information
+	r = httptest.NewRequest("GET", "http://example.com", nil)
+	r.Header.Add("X-Forwarded-Proto", "https")
+	r.Header.Add("X-Forwarded-Prefix", "/other/path")
+	p4 := provider.GenericOAuth{}
+	state = MakeState(r, &p4, "nonce")
+	assert.Equal("nonce:generic-oauth:https://example.com/other/path", state)
+
+	// Path and a forwarded prefix should use the path
+	r = httptest.NewRequest("GET", "http://example.com/multi/path", nil)
+	r.Header.Add("X-Forwarded-Proto", "https")
+	r.Header.Add("X-Forwarded-Prefix", "/something")
+	p5 := provider.GenericOAuth{}
+	state = MakeState(r, &p5, "nonce")
+	assert.Equal("nonce:generic-oauth:https://example.com/multi/path", state)
 }
 
 func TestAuthNonce(t *testing.T) {


### PR DESCRIPTION
In most (all?) cases, traefik makes the forwardAuth request at the root of the server (/). This means that the user's requested path is lost in the authentication redirect. However, the prefix is sent along with the `X-Forwarded-Prefix` header, so we use that in addition to the requested path if the requested path is empty.

https://github.com/traefik/traefik/blob/c57876c116ebc375becaff476fbcf6f25c4db7f3/pkg/middlewares/auth/forward.go#L57

https://github.com/traefik/traefik/blob/c57876c116ebc375becaff476fbcf6f25c4db7f3/pkg/middlewares/auth/forward.go#L102

close #323
close #325