### PR TITLE
Avoid modifying method on HEAD requests

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -56,7 +56,14 @@ func (s *Server) buildRoutes() {
 // forwarded request so it's correctly routed by mux
 func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 	// Modify request
-	r.Method = r.Header.Get("X-Forwarded-Method")
+
+	/// Avoid HEAD bug
+	/// https://github.com/thomseddon/traefik-forward-auth/issues/156
+	var m = r.Header.Get("X-Forwarded-Method")
+	if m != "HEAD" {
+		r.Method = m
+	}
+
 	r.Host = r.Header.Get("X-Forwarded-Host")
 
 	// Read URI from header if we're acting as forward auth middleware


### PR DESCRIPTION
Traefik sends a forward auth request for every request, including HEAD methods, in order to validate if a request can continue.

Due to Go HTTP client being strict to the HTTP SPEC, the response of a HEAD does not include a body, while Traefik expects a validation response to be embedded, causing errors.

To mitigate this, when a X-Forwarded-Method is set as HEAD, we'll avoid modifying the HTTP Method response in order to send a body back, allowing head requests to by validated.

This is necessary even if an allow rule is set, otherwhise it will fail as well.

Mitagates:  https://github.com/thomseddon/traefik-forward-auth/issues/156