### PR TITLE
Add skip-verify-tls option for Generic OAuth2 provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
 FROM golang:1.23-alpine as builder
 
 # Setup
-RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth
-WORKDIR /go/src/github.com/thomseddon/traefik-forward-auth
+WORKDIR /build
 
 # Add libraries
 RUN apk add --no-cache git
 
+# Copy go mod files first for better layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
 # Copy & build
-ADD . /go/src/github.com/thomseddon/traefik-forward-auth/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -installsuffix nocgo -o /traefik-forward-auth github.com/thomseddon/traefik-forward-auth/cmd
+COPY . .
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on go build -a -installsuffix nocgo -o /traefik-forward-auth ./cmd
 
 # Copy into scratch container
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine as builder
+FROM golang:1.23-alpine as builder
 
 # Setup
 RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ You must set:
 You can also set:
 - `providers.generic-oauth.scope`- Any scopes that should be included in the request (default: profile, email)
 - `providers.generic-oauth.token-style` - How token is presented when querying the User URL. Can be `header` or `query`, defaults to `header`. With `header` the token is provided in an Authorization header, with query the token is provided in the `access_token` query string value.
+- `providers.generic-oauth.skip-verify-tls` Skips the TLS certificate verificatio when making requests to the authentication service. 
 
 Please see the [Provider Setup](https://github.com/thomseddon/traefik-forward-auth/wiki/Provider-Setup) wiki page for examples.
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+IMAGE_NAME="lracz/traefik-forward-auth"
+TAG="latest"
+
+# Enable Docker BuildKit
+export DOCKER_BUILDKIT=1
+
+# Build and push for multiple architectures
+docker buildx create --use
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ${IMAGE_NAME}:${TAG} --push .


### PR DESCRIPTION
This pull request adds a new configuration option `skip-verify-tls` for the Generic OAuth2 provider. This option allows skipping the TLS certificate verification when making requests to the authentication service.

# Changes

- Added `skip-verify-tls` configuration option for the Generic OAuth2 provider.
- Updated the README with documentation for the new option.

## Usage

To skip TLS certificate verification when using the Generic OAuth2 provider, set the `skip-verify-tls` option to `true`:

Resolves issue: #122 