### PR TITLE
Updated Dockerfile to correctly build arm64 image

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM golang:1.23-alpine as builder
 
 # Setup
 RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth


### PR DESCRIPTION
In order to get the arm container to build properly, I needed to update the go version to 1.23.