### PR TITLE
 Add authorization to an external authorization service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Application Options:
   --whitelist=                                          Only allow given email addresses, can be set multiple times [$WHITELIST]
   --port=                                               Port to listen on (default: 4181) [$PORT]
   --rule.<name>.<param>=                                Rule definitions, param can be: "action", "rule" or "provider"
+  --authorization-url                                   URL to use for forward authorization to another service [$AUTHORIZATION_URL]
 
 Google Provider:
   --providers.google.client-id=                         Client ID [$PROVIDERS_GOOGLE_CLIENT_ID]
@@ -361,6 +362,22 @@ All options can be supplied in any of the following ways, in the following prece
    ```
 
    Note: It is possible to break your redirect flow with rules, please be careful not to create an `allow` rule that matches your redirect_uri unless you know what you're doing. This limitation is being tracked in in #101 and the behaviour will change in future releases.
+
+- `authorization-url`
+
+   When defined, an authorization layer is added after the 'rules'.
+   
+  - A request with the following information is sent to the URL:
+       - `email`
+       - `request`
+           - `method`
+           - `host`
+           - `path`
+  - The user's authorization must be indicated by the following response:
+       - Status: `OK 200`
+       - Body: `Authorized`
+  - If the authorization service responds with anything else, the user will not be authorized to access the requested resource.
+
 
 ## Concepts
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Application Options:
   --whitelist=                                          Only allow given email addresses, can be set multiple times [$WHITELIST]
   --port=                                               Port to listen on (default: 4181) [$PORT]
   --rule.<name>.<param>=                                Rule definitions, param can be: "action", "rule" or "provider"
-  --authorization-url                                   URL to use for forward authorization to another service [$AUTHORIZATION_URL]
+  --authorization-url=                                   URL to use for forward authorization to another service [$AUTHORIZATION_URL]
 
 Google Provider:
   --providers.google.client-id=                         Client ID [$PROVIDERS_GOOGLE_CLIENT_ID]
@@ -366,7 +366,7 @@ All options can be supplied in any of the following ways, in the following prece
 - `authorization-url`
 
    When defined, an authorization layer is added after the 'rules'.
-   
+
   - A request with the following information is sent to the URL:
        - `email`
        - `request`

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Application Options:
   --whitelist=                                          Only allow given email addresses, can be set multiple times [$WHITELIST]
   --port=                                               Port to listen on (default: 4181) [$PORT]
   --rule.<name>.<param>=                                Rule definitions, param can be: "action", "rule" or "provider"
-  --authorization-url=                                   URL to use for forward authorization to another service [$AUTHORIZATION_URL]
+  --authorization-url=                                  URL to use for forward authorization to another service [$AUTHORIZATION_URL]
 
 Google Provider:
   --providers.google.client-id=                         Client ID [$PROVIDERS_GOOGLE_CLIENT_ID]

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -100,6 +100,7 @@ func ValidateEmail(email, ruleName string) bool {
 	return false
 }
 
+// ValidateRequest validates the request against the authorization service
 // and returns true if the request is authorized
 func ValidateRequest(r *http.Request, email string) bool {
 	if config.AuthorizationURL == "" {

--- a/internal/config.go
+++ b/internal/config.go
@@ -44,6 +44,8 @@ type Config struct {
 	Providers provider.Providers `group:"providers" namespace:"providers" env-namespace:"PROVIDERS"`
 	Rules     map[string]*Rule   `long:"rule.<name>.<param>" description:"Rule definitions, param can be: \"action\", \"rule\" or \"provider\""`
 
+	AuthorizationURL string `long:"authorization-url" env:"AUTHORIZATION_URL" description:"The URL used for forward authorization requests, the body of the request will be a JSON object with the following fields: \"email\", \"request\". The request field is an array of objects with the following fields: \"method\", \"host\", \"path\""`
+
 	// Filled during transformations
 	Secret   []byte `json:"-"`
 	Lifetime time.Duration

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -38,6 +38,7 @@ func TestConfigDefaults(t *testing.T) {
 	assert.Equal("/_oauth", c.Path)
 	assert.Len(c.Whitelist, 0)
 	assert.Equal(c.Port, 4181)
+	assert.Equal("", c.AuthorizationURL)
 
 	assert.Equal("select_account", c.Providers.Google.Prompt)
 }
@@ -52,6 +53,7 @@ func TestConfigParseArgs(t *testing.T) {
 		"--rule.1.rule=PathPrefix(`/one`)",
 		"--rule.two.action=auth",
 		"--rule.two.rule=\"Host(`two.com`) && Path(`/two`)\"",
+		"--authorization-url=http://authorize.example.org/authorize",
 		"--port=8000",
 	})
 	require.Nil(t, err)
@@ -60,6 +62,7 @@ func TestConfigParseArgs(t *testing.T) {
 	assert.Equal("cookiename", c.CookieName)
 	assert.Equal("csrfcookiename", c.CSRFCookieName)
 	assert.Equal("oidc", c.DefaultProvider)
+	assert.Equal("http://authorize.example.org/authorize", c.AuthorizationURL)
 	assert.Equal(8000, c.Port)
 
 	// Check rules

--- a/internal/server.go
+++ b/internal/server.go
@@ -112,6 +112,14 @@ func (s *Server) AuthHandler(providerName, rule string) http.HandlerFunc {
 			return
 		}
 
+		// Validate if request is authorized
+		authorized := ValidateRequest(r, email)
+		if !authorized {
+			logger.WithField("email", email).Debug("Request not authorized for user")
+			http.Error(w, "Not authorized", 403)
+			return
+		}
+
 		// Valid request
 		logger.Debug("Allowing valid request")
 		w.Header().Set("X-Forwarded-User", email)


### PR DESCRIPTION
This PR adds support for an optional external user authorization service.

When enabled, an additional authorization layer is applied after the existing rules. The service receives a request containing the user’s email and request metadata (method, host, path). Access is granted only if the service responds with status 200 OK and body Authorized. Any other response results in access being denied.

This enhancement allows for more fine-grained access control based on custom authorization logic.