### PR TITLE
Update golang version in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine as builder
+FROM golang:1.22-alpine AS builder
 
 # Setup
 RUN mkdir -p /go/src/github.com/thomseddon/traefik-forward-auth


### PR DESCRIPTION
Resolves:
error of "go mod unknown directive: toolchain" golang images pre 1.22 and WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match