### PR TITLE
Bound CSRF cookie accumulation with a count-gated purge

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,41 @@
+name: Publish image
+
+# Publishes to GHCR on tag push only, tagged with the git tag. No `latest`
+# tag is published on purpose so that watchtower cannot pull a new image
+# without an explicit, deliberate change to the pinned tag.
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+
+  publish:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/traefik-forward-auth:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 A minimal forward authentication service that provides OAuth/SSO login and authentication for the [traefik](https://github.com/containous/traefik) reverse proxy/load balancer.
 
+## Fork Divergence
+
+This is a fork of [thomseddon/traefik-forward-auth](https://github.com/thomseddon/traefik-forward-auth) carrying one behavioural change, described below. Everything else tracks upstream.
+
+**What changed.** `authRedirect()` in `internal/server.go` now counts the CSRF cookies already present on the incoming request and, if there are more than **5**, clears all of them before setting the new one. The threshold is the `maxCSRFCookies` constant in the same file.
+
+**Why.** Each auth redirect mints a *uniquely named* CSRF cookie (`buildCSRFCookieName()` appends the first six characters of the nonce) with a fixed 1 hour expiry. Upstream sets one on every request that reaches `authRedirect()` and only ever clears the single cookie matching the state nonce returned to `AuthCallbackHandler()`. Any auth flow that begins but never completes — background tab reloads, favicon requests, service workers, link prefetches — therefore leaks one cookie for a full hour. Across several protected services these accumulate faster than they expire, until the `Cookie:` request header exceeds the receiving server's header buffer and it answers `400 Bad Request - Request Header Or Cookie Too Large`. This bites hardest when the cookies are scoped to a parent domain, because they are then sent to services that do not use forward-auth at all. See upstream [#238](https://github.com/thomseddon/traefik-forward-auth/issues/238).
+
+**Why not the upstream fix.** Upstream [PR #295](https://github.com/thomseddon/traefik-forward-auth/pull/295) clears *all* CSRF cookies on *every* `authRedirect`. That is a full revert to single-cookie behaviour and so reintroduces [#113](https://github.com/thomseddon/traefik-forward-auth/issues/113), where concurrent auth flows clobber one another's CSRF cookie and whichever flow completes second fails. Gating the purge on a count keeps growth bounded while leaving normal parallel flows working: up to 5 simultaneous in-flight logins behave exactly as upstream does today.
+
+**Tradeoff.** The #113 failure mode is not eliminated, only made much harder to hit — more than 5 auth flows genuinely in flight at once will still lose the older cookies. In exchange the cookie jar cannot grow without bound. This fork also uses `strings.HasPrefix` rather than PR #295's `strings.Contains`, so only cookies actually named for the configured `csrf-cookie-name` prefix are considered.
+
+**Images.** Published to `ghcr.io/stuckj/traefik-forward-auth` by `.github/workflows/ghcr.yml` on tag push, tagged with the git tag only. No `latest` tag is published, so upgrades must be a deliberate change to the pinned tag.
+
 ## Why?
 
 - Seamlessly overlays any http service with a single endpoint (see: `url-path` in [Configuration](#configuration))
@@ -16,6 +30,7 @@ A minimal forward authentication service that provides OAuth/SSO login and authe
 
 # Contents
 
+- [Fork Divergence](#fork-divergence)
 - [Releases](#releases)
 - [Usage](#usage)
   - [Simple](#simple)

--- a/internal/server.go
+++ b/internal/server.go
@@ -3,11 +3,18 @@ package tfa
 import (
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/thomseddon/traefik-forward-auth/internal/provider"
 	muxhttp "github.com/traefik/traefik/v2/pkg/muxer/http"
 )
+
+// maxCSRFCookies is the number of CSRF cookies a request may already carry
+// before authRedirect purges them all. Auth flows that never complete leave
+// their (uniquely named, 1h) CSRF cookie behind, so this bounds accumulation
+// while still permitting a reasonable number of concurrent logins.
+const maxCSRFCookies = 5
 
 // Server contains muxer and handler methods
 type Server struct {
@@ -222,6 +229,21 @@ func (s *Server) authRedirect(logger *logrus.Entry, w http.ResponseWriter, r *ht
 		logger.WithField("error", err).Error("Error generating nonce")
 		http.Error(w, "Service unavailable", 503)
 		return
+	}
+
+	// Purge accumulated CSRF cookies once past the threshold. Auth flows that
+	// never complete (background reloads, prefetches) leave their uniquely
+	// named cookie behind for its full 1h lifetime, which can outpace expiry.
+	var csrfCookies []*http.Cookie
+	for _, v := range r.Cookies() {
+		if strings.HasPrefix(v.Name, config.CSRFCookieName) {
+			csrfCookies = append(csrfCookies, v)
+		}
+	}
+	if len(csrfCookies) > maxCSRFCookies {
+		for _, v := range csrfCookies {
+			http.SetCookie(w, ClearCSRFCookie(r, v))
+		}
 	}
 
 	// Set the CSRF cookie

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -160,6 +160,39 @@ func TestServerAuthHandlerValid(t *testing.T) {
 	assert.Equal([]string{"test@example.com"}, users, "X-Forwarded-User header should match user")
 }
 
+func TestServerAuthHandlerCSRFCookiePurge(t *testing.T) {
+	assert := assert.New(t)
+	config = newDefaultConfig()
+
+	// At the threshold, existing csrf cookies should be left in place
+	req := newDefaultHttpRequest("/foo")
+	addCSRFCookies(req, maxCSRFCookies)
+
+	res, _ := doHttpRequest(req, nil)
+	assert.Equal(307, res.StatusCode, "request without auth cookie should be redirected")
+
+	cleared, set := splitCSRFCookies(res)
+	assert.Len(cleared, 0, "csrf cookies should not be purged at the threshold")
+	assert.Len(set, 1, "a new csrf cookie should be set")
+
+	// Above the threshold, every existing csrf cookie should be cleared
+	req = newDefaultHttpRequest("/foo")
+	addCSRFCookies(req, maxCSRFCookies+1)
+
+	res, _ = doHttpRequest(req, nil)
+	assert.Equal(307, res.StatusCode, "request without auth cookie should be redirected")
+
+	cleared, set = splitCSRFCookies(res)
+	assert.Len(cleared, maxCSRFCookies+1, "all csrf cookies should be purged above the threshold")
+	assert.Len(set, 1, "a new csrf cookie should still be set")
+
+	// Purging must not touch cookies belonging to anything else
+	for _, c := range res.Cookies() {
+		assert.True(strings.HasPrefix(c.Name, config.CSRFCookieName),
+			"only csrf cookies should be modified, got "+c.Name)
+	}
+}
+
 func TestServerAuthCallback(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -550,6 +583,33 @@ func doHttpRequest(r *http.Request, c *http.Cookie) (*http.Response, string) {
 	// }
 
 	return res, string(body)
+}
+
+// addCSRFCookies adds n uniquely named csrf cookies to a request, mimicking
+// the cookies left behind by auth flows that were started but never completed.
+func addCSRFCookies(r *http.Request, n int) {
+	for i := 0; i < n; i++ {
+		r.AddCookie(&http.Cookie{
+			Name:  fmt.Sprintf("%s_%06d", config.CSRFCookieName, i),
+			Value: "01234567890123456789012345678901",
+		})
+	}
+}
+
+// splitCSRFCookies partitions the csrf cookies on a response into those being
+// cleared (empty value, expiry in the past) and those being set.
+func splitCSRFCookies(res *http.Response) (cleared, set []*http.Cookie) {
+	for _, c := range res.Cookies() {
+		if !strings.HasPrefix(c.Name, config.CSRFCookieName) {
+			continue
+		}
+		if c.Value == "" && c.Expires.Before(time.Now()) {
+			cleared = append(cleared, c)
+		} else {
+			set = append(set, c)
+		}
+	}
+	return
 }
 
 func newDefaultConfig() *Config {


### PR DESCRIPTION
Every call to authRedirect() mints a *uniquely named* CSRF cookie: buildCSRFCookieName() appends the first six characters of the nonce to config.CSRFCookieName, and MakeCSRFCookie() gives it a fixed 1 hour expiry. Upstream sets one of these on every request that reaches authRedirect(), but AuthCallbackHandler() only ever clears the single cookie whose name matches the nonce in the returned state.

The result is that any auth flow which starts but never completes - background tab reloads, favicon requests, service workers, link prefetches - leaks one cookie for a full hour. Across several protected services these accumulate faster than they expire. Once the Cookie: request header outgrows the receiving server's header buffer that server answers 400 Bad Request - Request Header Or Cookie Too Large. Where the cookies are scoped to a parent domain they are sent to services that do not use forward-auth at all, so unrelated backends are taken down too (e.g. nginx with the default 8k large_client_header_buffers).

Fix: before setting the new cookie, count the CSRF cookies already on the request and, if there are more than maxCSRFCookies (5), clear all of them.

This deliberately differs from upstream PR #295, which clears every CSRF cookie on every redirect. That is a full revert to single-cookie behaviour and reintroduces #113, where concurrent auth flows clobber each other's CSRF cookie. Gating on a count bounds growth while leaving normal parallel flows working. It also matches on strings.HasPrefix rather than PR #295's strings.Contains, so only cookies actually named for the configured csrf-cookie-name prefix are touched.

Refs: #238, #113, #295